### PR TITLE
Add static assets for blog styling

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -37,6 +37,9 @@ module.exports = function (eleventyConfig) {
     api.getFilteredByGlob("blog-src/posts/**/index.md").sort((a, b) => b.date - a.date)
   );
 
+  // Copy static assets (e.g., CSS) to the published blog directory
+  eleventyConfig.addPassthroughCopy({ "blog-src/static": "static" });
+
   return {
     dir: { input: "blog-src", output: "blog", includes: "_includes", data: "_data" },
     markdownTemplateEngine: "njk",

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -1,0 +1,84 @@
+/* Blog global styles */
+:root {
+  color-scheme: light dark;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: #f5f7fa;
+  color: #1f2933;
+  line-height: 1.6;
+}
+
+a {
+  color: #0066cc;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+header,
+footer {
+  background: linear-gradient(135deg, #1f7aec, #45b6fe);
+  color: white;
+  padding: 1.5rem 1rem;
+}
+
+main {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+article {
+  background-color: white;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+article h1,
+article h2,
+article h3 {
+  color: #0f172a;
+}
+
+code,
+pre {
+  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background-color: #0f172a0d;
+}
+
+pre {
+  overflow-x: auto;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+blockquote {
+  border-left: 0.25rem solid #45b6fe;
+  background-color: #e9f5ff;
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+}
+
+img {
+  max-width: 100%;
+  border-radius: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 1.5rem 1rem;
+  }
+
+  article {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static stylesheet for the blog build output
- configure Eleventy to passthrough-copy the static assets directory into the published blog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0663beda08332b7e886d16cdb6afb