### PR TITLE
Fix blog URLs to include /blog prefix

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -34,7 +34,24 @@ module.exports = function (eleventyConfig) {
 
   // Posts collection (newest first)
   eleventyConfig.addCollection("posts", (api) =>
-    api.getFilteredByGlob("blog-src/posts/**/index.md").sort((a, b) => b.date - a.date)
+    api
+      .getFilteredByGlob("blog-src/posts/**/index.md")
+      .map((post) => {
+        if (post && post.url && !post.url.startsWith("/blog/")) {
+          post.url = `/blog${post.url}`;
+        }
+        if (
+          post &&
+          post.data &&
+          post.data.page &&
+          typeof post.data.page.url === "string" &&
+          !post.data.page.url.startsWith("/blog/")
+        ) {
+          post.data.page.url = `/blog${post.data.page.url}`;
+        }
+        return post;
+      })
+      .sort((a, b) => b.date - a.date)
   );
 
   // Copy static assets (e.g., CSS) to the published blog directory

--- a/blog-src/_includes/layouts/base.njk
+++ b/blog-src/_includes/layouts/base.njk
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="{{ description or 'Guides, tips, and insights about luggage scales, travel hacks, and smart packing.' }}">
 
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  <link rel="canonical" href="{{ page.url | absoluteUrl(config.site) }}">
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>

--- a/blog-src/index.njk
+++ b/blog-src/index.njk
@@ -22,9 +22,9 @@ permalink: "{% if pagination.pageNumber == 0 %}index.html{% else %}page-{{ pagin
 
 <nav>
   {% if pagination.href.previous %}
-    <a href="{{ pagination.href.previous }}">← Newer Posts</a>
+    <a href="{{ pagination.href.previous | url }}">← Newer Posts</a>
   {% endif %}
   {% if pagination.href.next %}
-    <a href="{{ pagination.href.next }}">Older Posts →</a>
+    <a href="{{ pagination.href.next | url }}">Older Posts →</a>
   {% endif %}
 </nav>

--- a/blog/index.html
+++ b/blog/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
 
-  <link rel="canonical" href="/">
+  <link rel="canonical" href="https://luggage-scale.com/blog/">
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>
@@ -23,52 +23,52 @@
 <ul>
   
     <li>
-      <a href="/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</a>
+      <a href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</a>
       — September 20, 2025
     </li>
   
     <li>
-      <a href="/business-travel-weekly-packing-system-to-eliminate-overages/">Business Travel: Weekly Packing System to Eliminate Overages</a>
+      <a href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Business Travel: Weekly Packing System to Eliminate Overages</a>
       — September 19, 2025
     </li>
   
     <li>
-      <a href="/calibrate-verify-trusting-your-luggage-scale-s-readout/">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</a>
+      <a href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</a>
       — September 18, 2025
     </li>
   
     <li>
-      <a href="/hello-world/">Hello World — First Blog Post</a>
+      <a href="/blog/hello-world/">Hello World — First Blog Post</a>
       — September 18, 2025
     </li>
   
     <li>
-      <a href="/international-vs-domestic-trips-planning-for-weight-differences/">International vs. Domestic Trips: Planning for Weight Differences</a>
+      <a href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">International vs. Domestic Trips: Planning for Weight Differences</a>
       — September 17, 2025
     </li>
   
     <li>
-      <a href="/family-travel-checklist-weigh-every-bag-in-2-minutes/">Family Travel Checklist: Weigh Every Bag in 2 Minutes</a>
+      <a href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Family Travel Checklist: Weigh Every Bag in 2 Minutes</a>
       — September 16, 2025
     </li>
   
     <li>
-      <a href="/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</a>
+      <a href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</a>
       — September 15, 2025
     </li>
   
     <li>
-      <a href="/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</a>
+      <a href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</a>
       — September 14, 2025
     </li>
   
     <li>
-      <a href="/carry-on-weight-limits-what-to-know-always-check-your-airline/">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</a>
+      <a href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</a>
       — September 13, 2025
     </li>
   
     <li>
-      <a href="/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</a>
+      <a href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</a>
       — September 12, 2025
     </li>
   
@@ -77,7 +77,7 @@
 <nav>
   
   
-    <a href="/page-2/">Older Posts →</a>
+    <a href="/blog/page-2/">Older Posts →</a>
   
 </nav>
 

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
 
-  <link rel="canonical" href="/page-2/">
+  <link rel="canonical" href="https://luggage-scale.com/blog/page-2/">
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>
@@ -23,7 +23,7 @@
 <ul>
   
     <li>
-      <a href="/avoid-overweight-baggage-fees-with-a-luggage-scale/">Avoid Overweight Baggage Fees with a Luggage Scale</a>
+      <a href="/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Avoid Overweight Baggage Fees with a Luggage Scale</a>
       — September 11, 2025
     </li>
   
@@ -31,7 +31,7 @@
 
 <nav>
   
-    <a href="/">← Newer Posts</a>
+    <a href="/blog/">← Newer Posts</a>
   
   
 </nav>


### PR DESCRIPTION
## Summary
- ensure the Eleventy posts collection prefixes generated URLs with `/blog/`
- update the base layout canonical link and pagination links so HTML emits the blog base path
- rebuild the blog so index and archive pages link to `/blog/...`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06a880bd883328793775bbe39a9a7