### PR TITLE
Add dedicated post layout with metadata

### DIFF
--- a/blog-src/_includes/head.njk
+++ b/blog-src/_includes/head.njk
@@ -5,13 +5,14 @@
 <title>{{ title or "Luggage Scale Blog" }}</title>
 <meta name="description" content="{{ description or 'Guides, tips, and insights about luggage scales, travel hacks, and smart packing.' }}">
 
-<link rel="canonical" href="{{ site.url }}{{ page.url | url }}">
+{% set canonicalHref = canonicalUrl or (site.url ~ (page.url | url)) %}
+<link rel="canonical" href="{{ canonicalHref }}">
 
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="{{ site.name }}">
 <meta property="og:title" content="{{ title or 'Blog' }}">
 <meta property="og:description" content="{{ description or 'Latest articles from the uPatch luggage scale team.' }}">
-<meta property="og:url" content="{{ site.url }}{{ page.url | url }}">
+<meta property="og:url" content="{{ canonicalHref }}">
 <meta property="og:image" content="{{ site.url }}/blog/static/logo.png">
 
 <meta name="twitter:card" content="summary_large_image">

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -1,0 +1,63 @@
+{% set metaDescription = description or excerpt or config.seo.defaultDescription %}
+{% set headSite = {
+  "name": config.site.name,
+  "url": config.site.url,
+  "twitter": config.seo.twitter
+} %}
+<!doctype html>
+<html lang="en">
+<head>
+  {% set site = headSite %}
+  {% set description = metaDescription %}
+  {% include "head.njk" %}
+  <link rel="stylesheet" href="{{ config.site.base }}/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="{{ config.site.base }}/"><strong>{{ config.site.name }}</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="{{ canonicalUrl }}">
+      <header class="post__header">
+        {% if title %}
+        <h1 class="post__title">{{ title }}</h1>
+        {% endif %}
+        <div class="post__meta">
+          {% if author %}
+          <span class="post__author">By {{ author }}</span>
+          {% endif %}
+          {% if date %}
+          {% if author %}<span class="post__meta-separator" aria-hidden="true">•</span>{% endif %}
+          <time class="post__date" datetime="{{ date | isoDate }}">{{ date | date("MMMM d, yyyy") }}</time>
+          {% endif %}
+        </div>
+        {% set summary = excerpt or description or config.seo.defaultDescription %}
+        {% if summary %}
+        <p class="post__excerpt">{{ summary }}</p>
+        {% endif %}
+      </header>
+
+      <div class="post__body">
+        {{ content | safe }}
+      </div>
+
+      {% if affiliateDisclaimer %}
+      <aside class="post__disclaimer">
+        {{ affiliateDisclaimer }}
+      </aside>
+      {% endif %}
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © {{ "now" | date("yyyy") }} —
+      <a href="{{ config.site.base }}/">Blog Index</a> •
+      <a href="{{ config.site.base }}/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog-src/posts/posts.json
+++ b/blog-src/posts/posts.json
@@ -1,4 +1,10 @@
 {
+  "layout": "layouts/post.njk",
   "permalink": "/{{ page.fileSlug }}/",
-  "tags": ["post"]
+  "tags": ["post"],
+  "author": "uPatch Travel Team",
+  "affiliateDisclaimer": "This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.",
+  "eleventyComputed": {
+    "canonicalUrl": "{{ page.url | absoluteUrl(config.site) }}"
+  }
 }

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -49,6 +49,63 @@ article h3 {
   color: #0f172a;
 }
 
+.post__header {
+  margin-bottom: 2rem;
+}
+
+.post__title {
+  margin: 0 0 0.5rem;
+  font-size: 2.25rem;
+  line-height: 1.1;
+}
+
+.post__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.95rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.post__meta-separator {
+  color: #94a3b8;
+}
+
+.post__excerpt {
+  margin: 1.25rem 0 0;
+  padding: 1rem 1.25rem;
+  background-color: #f1f5f9;
+  border-left: 0.25rem solid #1f7aec;
+  border-radius: 0.5rem;
+  font-size: 1.1rem;
+  color: #1e293b;
+}
+
+.post__body {
+  font-size: 1.05rem;
+}
+
+.post__body > :first-child {
+  margin-top: 0;
+}
+
+.post__body p {
+  margin-bottom: 1.25rem;
+}
+
+.post__disclaimer {
+  margin-top: 2.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  background: #e0f2fe;
+  color: #0f172a;
+  font-size: 0.95rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
 code,
 pre {
   font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -1,4 +1,62 @@
-<h1>Avoid Overweight Baggage Fees with a Luggage Scale</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Avoid Overweight Baggage Fees with a Luggage Scale</title>
+<meta name="description" content="A practical, airline‑agnostic guide to weigh bags at home and at the airport.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Avoid Overweight Baggage Fees with a Luggage Scale">
+<meta property="og:description" content="A practical, airline‑agnostic guide to weigh bags at home and at the airport.">
+<meta property="og:url" content="https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Avoid Overweight Baggage Fees with a Luggage Scale</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-11">September 11, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">A practical, airline‑agnostic guide to weigh bags at home and at the airport.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Avoid Overweight Baggage Fees with a Luggage Scale</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -1,4 +1,62 @@
-<h1>Business Travel: Weekly Packing System to Eliminate Overages</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Business Travel: Weekly Packing System to Eliminate Overages</title>
+<meta name="description" content="A repeatable workflow that keeps your roller under the limit.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Business Travel: Weekly Packing System to Eliminate Overages">
+<meta property="og:description" content="A repeatable workflow that keeps your roller under the limit.">
+<meta property="og:url" content="https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Business Travel: Weekly Packing System to Eliminate Overages</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-19">September 19, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">A repeatable workflow that keeps your roller under the limit.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Business Travel: Weekly Packing System to Eliminate Overages</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -1,4 +1,62 @@
-<h1>Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</title>
+<meta name="description" content="Sanity checks you can do at home to validate your scale’s accuracy.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout">
+<meta property="og:description" content="Sanity checks you can do at home to validate your scale’s accuracy.">
+<meta property="og:url" content="https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-18">September 18, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Sanity checks you can do at home to validate your scale’s accuracy.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -1,4 +1,62 @@
-<h1>Carry‑On Weight Limits: What to Know (Always Check Your Airline)</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Carry‑On Weight Limits: What to Know (Always Check Your Airline)</title>
+<meta name="description" content="Overview of carry‑on weight considerations and how to stay under.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Carry‑On Weight Limits: What to Know (Always Check Your Airline)">
+<meta property="og:description" content="Overview of carry‑on weight considerations and how to stay under.">
+<meta property="og:url" content="https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-13">September 13, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Overview of carry‑on weight considerations and how to stay under.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Carry‑On Weight Limits: What to Know (Always Check Your Airline)</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -1,4 +1,62 @@
-<h1>Family Travel Checklist: Weigh Every Bag in 2 Minutes</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Family Travel Checklist: Weigh Every Bag in 2 Minutes</title>
+<meta name="description" content="Fast routine to check all family luggage before leaving for the airport.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Family Travel Checklist: Weigh Every Bag in 2 Minutes">
+<meta property="og:description" content="Fast routine to check all family luggage before leaving for the airport.">
+<meta property="og:url" content="https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Family Travel Checklist: Weigh Every Bag in 2 Minutes</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-16">September 16, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Fast routine to check all family luggage before leaving for the airport.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Family Travel Checklist: Weigh Every Bag in 2 Minutes</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -1,6 +1,84 @@
-<p>This is your <strong>first test post</strong> in the new blog system.</p>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Hello World — First Blog Post</title>
+<meta name="description" content="Testing the new blog setup.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/hello-world/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Hello World — First Blog Post">
+<meta property="og:description" content="Testing the new blog setup.">
+<meta property="og:url" content="https://luggage-scale.com/blog/hello-world/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/hello-world/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Hello World — First Blog Post</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-18">September 18, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Testing the new blog setup.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <p>This is your <strong>first test post</strong> in the new blog system.</p>
 <ul>
 <li>Written in Markdown</li>
 <li>Stored in <code>/blog-src/posts/hello-world/index.md</code></li>
 <li>When built, it will publish to <code>/blog/hello-world/</code></li>
 </ul>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -1,4 +1,62 @@
-<h1>How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</title>
+<meta name="description" content="Step‑by‑step instructions for reliable readings without batteries.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale">
+<meta property="og:description" content="Step‑by‑step instructions for reliable readings without batteries.">
+<meta property="og:url" content="https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
+      <header class="post__header">
+        
+        <h1 class="post__title">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-12">September 12, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Step‑by‑step instructions for reliable readings without batteries.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -1,4 +1,62 @@
-<h1>International vs. Domestic Trips: Planning for Weight Differences</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>International vs. Domestic Trips: Planning for Weight Differences</title>
+<meta name="description" content="Key differences to consider and how a scale keeps you compliant.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="International vs. Domestic Trips: Planning for Weight Differences">
+<meta property="og:description" content="Key differences to consider and how a scale keeps you compliant.">
+<meta property="og:url" content="https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/">
+      <header class="post__header">
+        
+        <h1 class="post__title">International vs. Domestic Trips: Planning for Weight Differences</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-17">September 17, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Key differences to consider and how a scale keeps you compliant.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>International vs. Domestic Trips: Planning for Weight Differences</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -1,4 +1,62 @@
-<h1>Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</title>
+<meta name="description" content="Simple packing strategies to avoid check‑in surprises.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb">
+<meta property="og:description" content="Simple packing strategies to avoid check‑in surprises.">
+<meta property="og:url" content="https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-14">September 14, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Simple packing strategies to avoid check‑in surprises.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -49,6 +49,63 @@ article h3 {
   color: #0f172a;
 }
 
+.post__header {
+  margin-bottom: 2rem;
+}
+
+.post__title {
+  margin: 0 0 0.5rem;
+  font-size: 2.25rem;
+  line-height: 1.1;
+}
+
+.post__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.95rem;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.post__meta-separator {
+  color: #94a3b8;
+}
+
+.post__excerpt {
+  margin: 1.25rem 0 0;
+  padding: 1rem 1.25rem;
+  background-color: #f1f5f9;
+  border-left: 0.25rem solid #1f7aec;
+  border-radius: 0.5rem;
+  font-size: 1.1rem;
+  color: #1e293b;
+}
+
+.post__body {
+  font-size: 1.05rem;
+}
+
+.post__body > :first-child {
+  margin-top: 0;
+}
+
+.post__body p {
+  margin-bottom: 1.25rem;
+}
+
+.post__disclaimer {
+  margin-top: 2.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  background: #e0f2fe;
+  color: #0f172a;
+  font-size: 0.95rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
 code,
 pre {
   font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -1,4 +1,62 @@
-<h1>Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</title>
+<meta name="description" content="Techniques for accurate weighing when handles or shapes make it tricky.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)">
+<meta property="og:description" content="Techniques for accurate weighing when handles or shapes make it tricky.">
+<meta property="og:url" content="https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-15">September 15, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Techniques for accurate weighing when handles or shapes make it tricky.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -1,4 +1,62 @@
-<h1>Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</h1>
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</title>
+<meta name="description" content="Keep weight under control when your wardrobe runs heavy.">
+
+
+<link rel="canonical" href="https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Winter Gear Strategy: Coats, Boots, and Heavy Fabrics">
+<meta property="og:description" content="Keep weight under control when your wardrobe runs heavy.">
+<meta property="og:url" content="https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@upatch_scale">
+
+  <link rel="stylesheet" href="/blog/static/style.css">
+</head>
+<body class="post-page">
+  <header class="site-header">
+    <div class="container">
+      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+    </div>
+  </header>
+
+  <main class="container">
+    <article class="post" data-canonical="https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
+      <header class="post__header">
+        
+        <h1 class="post__title">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</h1>
+        
+        <div class="post__meta">
+          
+          <span class="post__author">By uPatch Travel Team</span>
+          
+          
+          <span class="post__meta-separator" aria-hidden="true">•</span>
+          <time class="post__date" datetime="2025-09-20">September 20, 2025</time>
+          
+        </div>
+        
+        
+        <p class="post__excerpt">Keep weight under control when your wardrobe runs heavy.</p>
+        
+      </header>
+
+      <div class="post__body">
+        <h1>Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</h1>
 <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
@@ -27,3 +85,23 @@
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+
+      </div>
+
+      
+      <aside class="post__disclaimer">
+        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+      </aside>
+      
+    </article>
+  </main>
+
+  <footer>
+    <div class="container">
+      © 2025 —
+      <a href="/blog/">Blog Index</a> •
+      <a href="/blog/sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a post layout that wraps article content in the blog scaffold, pulls in the shared head include, and renders author/date/excerpt/disclaimer blocks
- update the post collection defaults to opt into the new layout, provide canonical URLs, and expose author/affiliate placeholders for design hooks
- refresh styling hooks and rebuild the blog output so each post now emits full HTML with the expanded metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0a2d9b2d48332b3642d4c7975eb9c