### PR TITLE
Use absoluteUrl filter for canonical metadata

### DIFF
--- a/blog-src/_includes/blog.njk
+++ b/blog-src/_includes/blog.njk
@@ -12,6 +12,13 @@ permalink: "index.html"
 <!doctype html>
 <html lang="en">
 <head>
+  {% set headSite = {
+    "name": config.site.name,
+    "url": config.site.url,
+    "base": config.site.base,
+    "twitter": config.seo.twitter
+  } %}
+  {% set site = headSite %}
   {% include "head.njk" %}
 </head>
 <body>

--- a/blog-src/_includes/head.njk
+++ b/blog-src/_includes/head.njk
@@ -5,7 +5,7 @@
 <title>{{ title or "Luggage Scale Blog" }}</title>
 <meta name="description" content="{{ description or 'Guides, tips, and insights about luggage scales, travel hacks, and smart packing.' }}">
 
-{% set canonicalHref = canonicalUrl or (site.url ~ (page.url | url)) %}
+{% set canonicalHref = canonicalUrl or (page.url | absoluteUrl(site)) %}
 <link rel="canonical" href="{{ canonicalHref }}">
 
 <meta property="og:type" content="article">

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -2,6 +2,7 @@
 {% set headSite = {
   "name": config.site.name,
   "url": config.site.url,
+  "base": config.site.base,
   "twitter": config.seo.twitter
 } %}
 <!doctype html>


### PR DESCRIPTION
## Summary
- use the absoluteUrl filter when building canonical and og:url metadata in the head include
- pass the site configuration (including base) into the head include from the post and blog layouts to satisfy the filter
- confirmed the Eleventy configuration continues to export pathPrefix "/blog" alongside matching config.site.base data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0a7381a4483329901ec3e565884ac