### PR TITLE
Enhance blog metadata handling

### DIFF
--- a/blog-src/README.md
+++ b/blog-src/README.md
@@ -1,0 +1,24 @@
+# Blog authoring guide
+
+The Eleventy layouts compute SEO metadata from the page front matter. Provide the following keys whenever you create a new post or listing page so the shared `<head>` include can populate the Open Graph and Twitter tags correctly.
+
+## Core front matter keys
+
+| Key | Expected value | Used for |
+| --- | --------------- | -------- |
+| `title` | Plain text page title. Posts usually omit the brand name (it is appended automatically). | `<title>`, Open Graph title, on-page headings. |
+| `description` | One or two sentences (155–160 chars is ideal). | `<meta name="description">`, Open Graph/Twitter descriptions, teaser copy on listings. |
+| `socialImage` | Absolute URL or a `/blog/...` path to a 1200×630 image. | Open Graph/Twitter preview image. Falls back to `config.seo.defaultOgImage`. |
+| `author` | Display name for the article or page owner. | Visible post byline, `<meta name="author">`, `article:author`. Defaults to `uPatch Travel Team`. |
+| `published` | ISO date string (`YYYY-MM-DD`). For posts, match the Eleventy `date`. | `article:published_time` and canonical date displays. Optional for listings (layout will fall back to the build date). |
+
+## Optional helpers
+
+- `metaTitle` / `metaDescription` – override the computed title or description for the `<head>` tags when you need custom copy.
+- `ogType` – defaults to `article` on posts and `website` on listings. Override for landing pages that need a different Open Graph type.
+- `twitterCard` – defaults to `summary_large_image`; set to `summary` if you deliberately ship a smaller card.
+- `metaRobots` – supply custom robots directives (e.g., `noindex`) instead of using the automatic `published: false` guard.
+- `socialImageAlt` – short alt text for the social sharing image, applied to the `og:image:alt` and `twitter:image:alt` tags.
+- `authorTwitter` / `twitterCreator` – handle shown in the `twitter:creator` tag when the post has an author-specific account.
+
+All paths and URLs pass through the `absoluteUrl` filter, so relative paths under `/blog` automatically expand to fully-qualified URLs using the values in `_data/config.json`.

--- a/blog-src/_data/config.json
+++ b/blog-src/_data/config.json
@@ -8,6 +8,11 @@
   },
   "seo": {
     "twitter": "@upatch_scale",
-    "defaultDescription": "Guides, tips, and insights about luggage scales, travel hacks, and smart packing."
+    "defaultTitle": "Luggage Scale Blog",
+    "defaultDescription": "Guides, tips, and insights about luggage scales, travel hacks, and smart packing.",
+    "defaultOgImage": "/blog/static/logo.svg",
+    "defaultOgType": "website",
+    "defaultTwitterCard": "summary_large_image",
+    "defaultAuthor": "uPatch Travel Team"
   }
 }

--- a/blog-src/_includes/head.njk
+++ b/blog-src/_includes/head.njk
@@ -2,18 +2,83 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>{{ title or "Luggage Scale Blog" }}</title>
-<meta name="description" content="{{ description or 'Guides, tips, and insights about luggage scales, travel hacks, and smart packing.' }}">
+{% set headSite = site or {
+  "name": config.site.name,
+  "url": config.site.url,
+  "base": config.site.base,
+  "twitter": config.seo.twitter,
+  "logoPath": config.site.logoPath
+} %}
+{% set seoDefaults = config.seo or {} %}
 
-{% set canonicalHref = canonicalUrl or (page.url | absoluteUrl(site)) %}
+{% set computedMetaTitle = metaTitle or seoDefaults.defaultTitle or headSite.name %}
+{% set computedMetaDescription = metaDescription or seoDefaults.defaultDescription %}
+{% set canonicalHref = canonicalUrl or (page.url | absoluteUrl(headSite)) %}
+{% set computedOgType = ogType or seoDefaults.defaultOgType or "website" %}
+{% set computedOgImage = ogImage or seoDefaults.defaultOgImage or headSite.logoPath %}
+{% set computedOgImageAlt = ogImageAlt %}
+{% if computedOgImage and computedOgImage is string and not computedOgImage.startsWith("http") %}
+  {% set computedOgImage = computedOgImage | absoluteUrl(headSite) %}
+{% endif %}
+{% set computedTwitterCard = twitterCard or seoDefaults.defaultTwitterCard or "summary_large_image" %}
+{% set computedTwitterSite = twitterSite or headSite.twitter or seoDefaults.twitter %}
+{% set computedTwitterCreator = twitterCreator or authorTwitter or computedTwitterSite %}
+{% set computedMetaAuthor = metaAuthor or author or seoDefaults.defaultAuthor %}
+{% set robotsContent = metaRobots %}
+{% set publishedDate = articlePublished or published %}
+{% set modifiedDate = articleModified or updated %}
+
+<title>{{ computedMetaTitle }}</title>
+{% if computedMetaDescription %}
+<meta name="description" content="{{ computedMetaDescription }}">
+{% endif %}
 <link rel="canonical" href="{{ canonicalHref }}">
 
-<meta property="og:type" content="article">
-<meta property="og:site_name" content="{{ site.name }}">
-<meta property="og:title" content="{{ title or 'Blog' }}">
-<meta property="og:description" content="{{ description or 'Latest articles from the uPatch luggage scale team.' }}">
+<meta property="og:site_name" content="{{ headSite.name }}">
+<meta property="og:title" content="{{ computedMetaTitle }}">
+{% if computedMetaDescription %}
+<meta property="og:description" content="{{ computedMetaDescription }}">
+{% endif %}
 <meta property="og:url" content="{{ canonicalHref }}">
-<meta property="og:image" content="{{ site.url }}/blog/static/logo.png">
+<meta property="og:type" content="{{ computedOgType }}">
+{% if computedOgImage %}
+<meta property="og:image" content="{{ computedOgImage }}">
+  {% if computedOgImageAlt %}
+<meta property="og:image:alt" content="{{ computedOgImageAlt }}">
+  {% endif %}
+{% endif %}
 
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:site" content="{{ site.twitter }}">
+<meta name="twitter:card" content="{{ computedTwitterCard }}">
+{% if computedTwitterSite %}
+<meta name="twitter:site" content="{{ computedTwitterSite }}">
+{% endif %}
+{% if computedTwitterCreator %}
+<meta name="twitter:creator" content="{{ computedTwitterCreator }}">
+{% endif %}
+<meta name="twitter:title" content="{{ computedMetaTitle }}">
+{% if computedMetaDescription %}
+<meta name="twitter:description" content="{{ computedMetaDescription }}">
+{% endif %}
+{% if computedOgImage %}
+<meta name="twitter:image" content="{{ computedOgImage }}">
+  {% if computedOgImageAlt %}
+<meta name="twitter:image:alt" content="{{ computedOgImageAlt }}">
+  {% endif %}
+{% endif %}
+{% if computedMetaAuthor %}
+<meta name="author" content="{{ computedMetaAuthor }}">
+  {% if computedOgType == "article" %}
+  <meta property="article:author" content="{{ computedMetaAuthor }}">
+  {% endif %}
+{% endif %}
+{% if robotsContent %}
+<meta name="robots" content="{{ robotsContent }}">
+{% endif %}
+{% if computedOgType == "article" %}
+  {% if publishedDate %}
+  <meta property="article:published_time" content="{{ publishedDate | isoDate }}">
+  {% endif %}
+  {% if modifiedDate %}
+  <meta property="article:modified_time" content="{{ modifiedDate | isoDate }}">
+  {% endif %}
+{% endif %}

--- a/blog-src/_includes/layouts/base.njk
+++ b/blog-src/_includes/layouts/base.njk
@@ -1,18 +1,64 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>{{ title }} — Luggage Scale Blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="{{ description or 'Guides, tips, and insights about luggage scales, travel hacks, and smart packing.' }}">
+  {% set headSite = {
+    "name": config.site.name,
+    "url": config.site.url,
+    "base": config.site.base,
+    "twitter": config.seo.twitter,
+    "logoPath": config.site.logoPath
+  } %}
+  {% if metaTitle %}
+    {% set resolvedMetaTitle = metaTitle %}
+  {% elseif title %}
+    {% if config.site.name and title.indexOf(config.site.name) > -1 %}
+      {% set resolvedMetaTitle = title %}
+    {% else %}
+      {% set resolvedMetaTitle = title + " — " + config.site.name %}
+    {% endif %}
+  {% else %}
+    {% set resolvedMetaTitle = config.seo.defaultTitle or config.site.name %}
+  {% endif %}
+  {% set resolvedDescription = metaDescription or description or config.seo.defaultDescription %}
+  {% set resolvedOgImage = ogImage or socialImage or config.seo.defaultOgImage or headSite.logoPath %}
+  {% set resolvedOgType = ogType or config.seo.defaultOgType or "website" %}
+  {% set resolvedTwitterCard = twitterCard or config.seo.defaultTwitterCard or "summary_large_image" %}
+  {% set resolvedMetaAuthor = metaAuthor or author or config.seo.defaultAuthor %}
+  {% set resolvedOgImageAlt = ogImageAlt or socialImageAlt %}
+  {% set resolvedPublished = articlePublished or published %}
+  {% if not resolvedPublished and page and page.date %}
+    {% set resolvedPublished = page.date %}
+  {% endif %}
+  {% set resolvedModified = articleModified or updated or lastUpdated or revised %}
+  {% if metaRobots is defined %}
+    {% set resolvedRobots = metaRobots %}
+  {% else %}
+    {% set resolvedRobots = none %}
+    {% if published === false %}
+      {% set resolvedRobots = "noindex, nofollow" %}
+    {% endif %}
+  {% endif %}
+  {% set resolvedTwitterCreator = twitterCreator or authorTwitter %}
 
-  <link rel="canonical" href="{{ page.url | absoluteUrl(config.site) }}">
-  <link rel="stylesheet" href="/blog/static/style.css">
+  {% set site = headSite %}
+  {% set metaTitle = resolvedMetaTitle %}
+  {% set metaDescription = resolvedDescription %}
+  {% set ogImage = resolvedOgImage %}
+  {% set ogType = resolvedOgType %}
+  {% set twitterCard = resolvedTwitterCard %}
+  {% set metaAuthor = resolvedMetaAuthor %}
+  {% set ogImageAlt = resolvedOgImageAlt %}
+  {% set articlePublished = resolvedPublished %}
+  {% set articleModified = resolvedModified %}
+  {% set metaRobots = resolvedRobots %}
+  {% set twitterCreator = resolvedTwitterCreator %}
+  {% include "head.njk" %}
+  <link rel="stylesheet" href="{{ config.site.base }}/static/style.css">
 </head>
 <body>
   <header>
     <div class="container">
-      <a href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <a href="{{ config.site.base }}/"><strong>{{ config.site.name }}</strong></a>
     </div>
   </header>
 
@@ -23,8 +69,8 @@
   <footer>
     <div class="container">
       © {{ "now" | date("yyyy") }} —
-      <a href="/blog/">Blog Index</a> •
-      <a href="/blog/sitemap.xml">Sitemap</a>
+      <a href="{{ config.site.base }}/">Blog Index</a> •
+      <a href="{{ config.site.base }}/sitemap.xml">Sitemap</a>
     </div>
   </footer>
 </body>

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -1,15 +1,53 @@
-{% set metaDescription = description or excerpt or config.seo.defaultDescription %}
 {% set headSite = {
   "name": config.site.name,
   "url": config.site.url,
   "base": config.site.base,
-  "twitter": config.seo.twitter
+  "twitter": config.seo.twitter,
+  "logoPath": config.site.logoPath
 } %}
+{% if metaTitle %}
+  {% set resolvedMetaTitle = metaTitle %}
+{% elseif title %}
+  {% if config.site.name and title.indexOf(config.site.name) > -1 %}
+    {% set resolvedMetaTitle = title %}
+  {% else %}
+    {% set resolvedMetaTitle = title + " — " + config.site.name %}
+  {% endif %}
+{% else %}
+  {% set resolvedMetaTitle = config.seo.defaultTitle or config.site.name %}
+{% endif %}
+{% set resolvedDescription = metaDescription or description or excerpt or config.seo.defaultDescription %}
+{% set resolvedOgImage = ogImage or socialImage or config.seo.defaultOgImage or headSite.logoPath %}
+{% set resolvedOgType = ogType or "article" %}
+{% set resolvedTwitterCard = twitterCard or config.seo.defaultTwitterCard or "summary_large_image" %}
+{% set resolvedMetaAuthor = metaAuthor or author or config.seo.defaultAuthor %}
+{% set resolvedPublished = articlePublished or published or date or page.date %}
+{% set resolvedModified = articleModified or updated or lastUpdated or revised %}
+{% if metaRobots is defined %}
+  {% set resolvedRobots = metaRobots %}
+{% else %}
+  {% set resolvedRobots = none %}
+  {% if published === false %}
+    {% set resolvedRobots = "noindex, nofollow" %}
+  {% endif %}
+{% endif %}
+{% set resolvedTwitterCreator = twitterCreator or authorTwitter or config.seo.twitter %}
+{% set resolvedOgImageAlt = ogImageAlt or socialImageAlt %}
 <!doctype html>
 <html lang="en">
 <head>
   {% set site = headSite %}
-  {% set description = metaDescription %}
+  {% set metaTitle = resolvedMetaTitle %}
+  {% set metaDescription = resolvedDescription %}
+  {% set ogImage = resolvedOgImage %}
+  {% set ogType = resolvedOgType %}
+  {% set twitterCard = resolvedTwitterCard %}
+  {% set metaAuthor = resolvedMetaAuthor %}
+  {% set articlePublished = resolvedPublished %}
+  {% set articleModified = resolvedModified %}
+  {% set metaRobots = resolvedRobots %}
+  {% set twitterCreator = resolvedTwitterCreator %}
+  {% set ogImageAlt = resolvedOgImageAlt %}
   {% include "head.njk" %}
   <link rel="stylesheet" href="{{ config.site.base }}/static/style.css">
 </head>

--- a/blog-src/static/logo.svg
+++ b/blog-src/static/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">uPatch Luggage Scale</title>
+  <desc id="desc">Stylized luggage scale mark on a deep blue background</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#002F5F" />
+      <stop offset="100%" stop-color="#0B5CA5" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="48" ry="48" />
+  <g fill="#FFFFFF" aria-hidden="true">
+    <path d="M360 252c0-66.274 53.726-120 120-120h240c66.274 0 120 53.726 120 120v126c0 66.274-53.726 120-120 120H480c-66.274 0-120-53.726-120-120V252zm120-72c-39.765 0-72 32.235-72 72v126c0 39.765 32.235 72 72 72h240c39.765 0 72-32.235 72-72V252c0-39.765-32.235-72-72-72H480z"/>
+    <path d="M600 210c44.183 0 80 35.817 80 80s-35.817 80-80 80-80-35.817-80-80 35.817-80 80-80zm0 48c-17.673 0-32 14.327-32 32s14.327 32 32 32 32-14.327 32-32-14.327-32-32-32z"/>
+    <rect x="556" y="186" width="88" height="36" rx="18"/>
+  </g>
+  <text x="600" y="510" fill="#FFFFFF" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="80" font-weight="600" text-anchor="middle">
+    Luggage Scale
+  </text>
+</svg>

--- a/blog/README/index.html
+++ b/blog/README/index.html
@@ -1,0 +1,49 @@
+<h1>Blog authoring guide</h1>
+<p>The Eleventy layouts compute SEO metadata from the page front matter. Provide the following keys whenever you create a new post or listing page so the shared <code>&lt;head&gt;</code> include can populate the Open Graph and Twitter tags correctly.</p>
+<h2>Core front matter keys</h2>
+<table>
+<thead>
+<tr>
+<th>Key</th>
+<th>Expected value</th>
+<th>Used for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>title</code></td>
+<td>Plain text page title. Posts usually omit the brand name (it is appended automatically).</td>
+<td><code>&lt;title&gt;</code>, Open Graph title, on-page headings.</td>
+</tr>
+<tr>
+<td><code>description</code></td>
+<td>One or two sentences (155–160 chars is ideal).</td>
+<td><code>&lt;meta name=&quot;description&quot;&gt;</code>, Open Graph/Twitter descriptions, teaser copy on listings.</td>
+</tr>
+<tr>
+<td><code>socialImage</code></td>
+<td>Absolute URL or a <code>/blog/...</code> path to a 1200×630 image.</td>
+<td>Open Graph/Twitter preview image. Falls back to <code>config.seo.defaultOgImage</code>.</td>
+</tr>
+<tr>
+<td><code>author</code></td>
+<td>Display name for the article or page owner.</td>
+<td>Visible post byline, <code>&lt;meta name=&quot;author&quot;&gt;</code>, <code>article:author</code>. Defaults to <code>uPatch Travel Team</code>.</td>
+</tr>
+<tr>
+<td><code>published</code></td>
+<td>ISO date string (<code>YYYY-MM-DD</code>). For posts, match the Eleventy <code>date</code>.</td>
+<td><code>article:published_time</code> and canonical date displays. Optional for listings (layout will fall back to the build date).</td>
+</tr>
+</tbody>
+</table>
+<h2>Optional helpers</h2>
+<ul>
+<li><code>metaTitle</code> / <code>metaDescription</code> – override the computed title or description for the <code>&lt;head&gt;</code> tags when you need custom copy.</li>
+<li><code>ogType</code> – defaults to <code>article</code> on posts and <code>website</code> on listings. Override for landing pages that need a different Open Graph type.</li>
+<li><code>twitterCard</code> – defaults to <code>summary_large_image</code>; set to <code>summary</code> if you deliberately ship a smaller card.</li>
+<li><code>metaRobots</code> – supply custom robots directives (e.g., <code>noindex</code>) instead of using the automatic <code>published: false</code> guard.</li>
+<li><code>socialImageAlt</code> – short alt text for the social sharing image, applied to the <code>og:image:alt</code> and <code>twitter:image:alt</code> tags.</li>
+<li><code>authorTwitter</code> / <code>twitterCreator</code> – handle shown in the <code>twitter:creator</code> tag when the post has an author-specific account.</li>
+</ul>
+<p>All paths and URLs pass through the <code>absoluteUrl</code> filter, so relative paths under <code>/blog</code> automatically expand to fully-qualified URLs using the values in <code>_data/config.json</code>.</p>

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Avoid Overweight Baggage Fees with a Luggage Scale</title>
-<meta name="description" content="A practical, airline‑agnostic guide to weigh bags at home and at the airport.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Avoid Overweight Baggage Fees with a Luggage Scale — Luggage Scale Blog</title>
+
+<meta name="description" content="A practical, airline‑agnostic guide to weigh bags at home and at the airport.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Avoid Overweight Baggage Fees with a Luggage Scale">
+<meta property="og:title" content="Avoid Overweight Baggage Fees with a Luggage Scale — Luggage Scale Blog">
+
 <meta property="og:description" content="A practical, airline‑agnostic guide to weigh bags at home and at the airport.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Avoid Overweight Baggage Fees with a Luggage Scale — Luggage Scale Blog">
+
+<meta name="twitter:description" content="A practical, airline‑agnostic guide to weigh bags at home and at the airport.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-11">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Business Travel: Weekly Packing System to Eliminate Overages</title>
-<meta name="description" content="A repeatable workflow that keeps your roller under the limit.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Business Travel: Weekly Packing System to Eliminate Overages — Luggage Scale Blog</title>
+
+<meta name="description" content="A repeatable workflow that keeps your roller under the limit.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Business Travel: Weekly Packing System to Eliminate Overages">
+<meta property="og:title" content="Business Travel: Weekly Packing System to Eliminate Overages — Luggage Scale Blog">
+
 <meta property="og:description" content="A repeatable workflow that keeps your roller under the limit.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Business Travel: Weekly Packing System to Eliminate Overages — Luggage Scale Blog">
+
+<meta name="twitter:description" content="A repeatable workflow that keeps your roller under the limit.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-19">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</title>
-<meta name="description" content="Sanity checks you can do at home to validate your scale’s accuracy.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout — Luggage Scale Blog</title>
+
+<meta name="description" content="Sanity checks you can do at home to validate your scale’s accuracy.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout">
+<meta property="og:title" content="Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout — Luggage Scale Blog">
+
 <meta property="og:description" content="Sanity checks you can do at home to validate your scale’s accuracy.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Sanity checks you can do at home to validate your scale’s accuracy.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-18">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Carry‑On Weight Limits: What to Know (Always Check Your Airline)</title>
-<meta name="description" content="Overview of carry‑on weight considerations and how to stay under.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Carry‑On Weight Limits: What to Know (Always Check Your Airline) — Luggage Scale Blog</title>
+
+<meta name="description" content="Overview of carry‑on weight considerations and how to stay under.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Carry‑On Weight Limits: What to Know (Always Check Your Airline)">
+<meta property="og:title" content="Carry‑On Weight Limits: What to Know (Always Check Your Airline) — Luggage Scale Blog">
+
 <meta property="og:description" content="Overview of carry‑on weight considerations and how to stay under.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Carry‑On Weight Limits: What to Know (Always Check Your Airline) — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Overview of carry‑on weight considerations and how to stay under.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-13">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Family Travel Checklist: Weigh Every Bag in 2 Minutes</title>
-<meta name="description" content="Fast routine to check all family luggage before leaving for the airport.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Family Travel Checklist: Weigh Every Bag in 2 Minutes — Luggage Scale Blog</title>
+
+<meta name="description" content="Fast routine to check all family luggage before leaving for the airport.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Family Travel Checklist: Weigh Every Bag in 2 Minutes">
+<meta property="og:title" content="Family Travel Checklist: Weigh Every Bag in 2 Minutes — Luggage Scale Blog">
+
 <meta property="og:description" content="Fast routine to check all family luggage before leaving for the airport.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Family Travel Checklist: Weigh Every Bag in 2 Minutes — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Fast routine to check all family luggage before leaving for the airport.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-16">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Hello World — First Blog Post</title>
-<meta name="description" content="Testing the new blog setup.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Hello World — First Blog Post — Luggage Scale Blog</title>
+
+<meta name="description" content="Testing the new blog setup.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/hello-world/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Hello World — First Blog Post">
+<meta property="og:title" content="Hello World — First Blog Post — Luggage Scale Blog">
+
 <meta property="og:description" content="Testing the new blog setup.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/hello-world/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Hello World — First Blog Post — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Testing the new blog setup.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-18">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</title>
-<meta name="description" content="Step‑by‑step instructions for reliable readings without batteries.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale — Luggage Scale Blog</title>
+
+<meta name="description" content="Step‑by‑step instructions for reliable readings without batteries.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale">
+<meta property="og:title" content="How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale — Luggage Scale Blog">
+
 <meta property="og:description" content="Step‑by‑step instructions for reliable readings without batteries.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Step‑by‑step instructions for reliable readings without batteries.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-12">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,12 +1,105 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>Blog — Luggage Scale Blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+    
+  
+  
 
-  <link rel="canonical" href="https://luggage-scale.com/blog/">
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Blog — Luggage Scale Blog</title>
+
+<meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+
+<link rel="canonical" href="https://luggage-scale.com/blog/">
+
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Blog — Luggage Scale Blog">
+
+<meta property="og:description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+
+<meta property="og:url" content="https://luggage-scale.com/blog/">
+<meta property="og:type" content="website">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="twitter:card" content="summary_large_image">
+
+<meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Blog — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+
+
+
+
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>International vs. Domestic Trips: Planning for Weight Differences</title>
-<meta name="description" content="Key differences to consider and how a scale keeps you compliant.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>International vs. Domestic Trips: Planning for Weight Differences — Luggage Scale Blog</title>
+
+<meta name="description" content="Key differences to consider and how a scale keeps you compliant.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="International vs. Domestic Trips: Planning for Weight Differences">
+<meta property="og:title" content="International vs. Domestic Trips: Planning for Weight Differences — Luggage Scale Blog">
+
 <meta property="og:description" content="Key differences to consider and how a scale keeps you compliant.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="International vs. Domestic Trips: Planning for Weight Differences — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Key differences to consider and how a scale keeps you compliant.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-17">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</title>
-<meta name="description" content="Simple packing strategies to avoid check‑in surprises.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb — Luggage Scale Blog</title>
+
+<meta name="description" content="Simple packing strategies to avoid check‑in surprises.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb">
+<meta property="og:title" content="Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb — Luggage Scale Blog">
+
 <meta property="og:description" content="Simple packing strategies to avoid check‑in surprises.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Simple packing strategies to avoid check‑in surprises.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-14">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -1,12 +1,105 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>Blog — Luggage Scale Blog</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+    
+  
+  
 
-  <link rel="canonical" href="https://luggage-scale.com/blog/page-2/">
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Blog — Luggage Scale Blog</title>
+
+<meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+
+<link rel="canonical" href="https://luggage-scale.com/blog/page-2/">
+
+<meta property="og:site_name" content="Luggage Scale Blog">
+<meta property="og:title" content="Blog — Luggage Scale Blog">
+
+<meta property="og:description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+
+<meta property="og:url" content="https://luggage-scale.com/blog/page-2/">
+<meta property="og:type" content="website">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="twitter:card" content="summary_large_image">
+
+<meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Blog — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+
+
+
+
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>

--- a/blog/static/logo.svg
+++ b/blog/static/logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">uPatch Luggage Scale</title>
+  <desc id="desc">Stylized luggage scale mark on a deep blue background</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#002F5F" />
+      <stop offset="100%" stop-color="#0B5CA5" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="48" ry="48" />
+  <g fill="#FFFFFF" aria-hidden="true">
+    <path d="M360 252c0-66.274 53.726-120 120-120h240c66.274 0 120 53.726 120 120v126c0 66.274-53.726 120-120 120H480c-66.274 0-120-53.726-120-120V252zm120-72c-39.765 0-72 32.235-72 72v126c0 39.765 32.235 72 72 72h240c39.765 0 72-32.235 72-72V252c0-39.765-32.235-72-72-72H480z"/>
+    <path d="M600 210c44.183 0 80 35.817 80 80s-35.817 80-80 80-80-35.817-80-80 35.817-80 80-80zm0 48c-17.673 0-32 14.327-32 32s14.327 32 32 32 32-14.327 32-32-14.327-32-32-32z"/>
+    <rect x="556" y="186" width="88" height="36" rx="18"/>
+  </g>
+  <text x="600" y="510" fill="#FFFFFF" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="80" font-weight="600" text-anchor="middle">
+    Luggage Scale
+  </text>
+</svg>

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</title>
-<meta name="description" content="Techniques for accurate weighing when handles or shapes make it tricky.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments) — Luggage Scale Blog</title>
+
+<meta name="description" content="Techniques for accurate weighing when handles or shapes make it tricky.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)">
+<meta property="og:title" content="Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments) — Luggage Scale Blog">
+
 <meta property="og:description" content="Techniques for accurate weighing when handles or shapes make it tricky.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments) — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Techniques for accurate weighing when handles or shapes make it tricky.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-15">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -1,29 +1,107 @@
 
 
+  
+    
+  
+
+
+
+
+
+
+
+
+
+  
+  
+
+
+
 <!doctype html>
 <html lang="en">
 <head>
   
   
   
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<title>Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</title>
-<meta name="description" content="Keep weight under control when your wardrobe runs heavy.">
 
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+
+
+
+
+<title>Winter Gear Strategy: Coats, Boots, and Heavy Fabrics — Luggage Scale Blog</title>
+
+<meta name="description" content="Keep weight under control when your wardrobe runs heavy.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
 
-<meta property="og:type" content="article">
 <meta property="og:site_name" content="Luggage Scale Blog">
-<meta property="og:title" content="Winter Gear Strategy: Coats, Boots, and Heavy Fabrics">
+<meta property="og:title" content="Winter Gear Strategy: Coats, Boots, and Heavy Fabrics — Luggage Scale Blog">
+
 <meta property="og:description" content="Keep weight under control when your wardrobe runs heavy.">
+
 <meta property="og:url" content="https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
-<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.png">
+<meta property="og:type" content="article">
+
+<meta property="og:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
 
 <meta name="twitter:card" content="summary_large_image">
+
 <meta name="twitter:site" content="@upatch_scale">
+
+
+<meta name="twitter:creator" content="@upatch_scale">
+
+<meta name="twitter:title" content="Winter Gear Strategy: Coats, Boots, and Heavy Fabrics — Luggage Scale Blog">
+
+<meta name="twitter:description" content="Keep weight under control when your wardrobe runs heavy.">
+
+
+<meta name="twitter:image" content="https://luggage-scale.com/blog/static/logo.svg">
+  
+
+
+<meta name="author" content="uPatch Travel Team">
+  
+  <meta property="article:author" content="uPatch Travel Team">
+  
+
+
+
+  
+  <meta property="article:published_time" content="2025-09-20">
+  
+  
+
 
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>


### PR DESCRIPTION
## Summary
- extend the shared head include to honor explicit meta fields with config-driven defaults
- compute and pass metadata from the base and post layouts, including new default social logo
- document required front matter keys for posts/listings and add a default social logo asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0a8666c288332b11e932d69e427e6