### PR TITLE
Refine blog listing cards and metadata

### DIFF
--- a/blog-src/_includes/blog-list.njk
+++ b/blog-src/_includes/blog-list.njk
@@ -1,39 +1,44 @@
----
-layout: "base.njk"
-title: "Blog"
-description: "Latest articles, guides, and tips from the uPatch luggage scale team."
-pagination:
-  data: collections.posts
-  size: 10
-  alias: paged
-permalink: "{% if pagination.pageNumber == 0 %}index.html{% else %}page-{{ pagination.pageNumber + 1 }}/index.html{% endif %}"
----
-
-<h1>Blog</h1>
-
-<ul>
-  {% for post in paged %}
-    <li style="margin-bottom:1.5rem;">
-      <h2 style="margin:0;">
-        <a href="{{ post.url | url }}">{{ post.data.title }}</a>
-      </h2>
-      <div class="meta">
-        <time datetime="{{ post.date | isoDate }}">{{ post.date | date("MMMM d, yyyy") }}</time>
-      </div>
-      {% if post.data.description %}
-        <p>{{ post.data.description }}</p>
-      {% else %}
-        <p>{{ post.templateContent | striptags | truncate(160, true, "...") }}</p>
+{% set postsCollection = posts or paged or pagination.items or collections.posts %}
+{% if postsCollection and postsCollection | length %}
+<ul class="blog-list">
+  {% for post in postsCollection %}
+    {% set authorName = post.data.author or config.seo.defaultAuthor or "uPatch Travel Team" %}
+    {% set summaryText = post.data.excerpt or post.data.metaDescription or post.data.description %}
+    {% if not summaryText %}
+      {% set summaryText %}{{ post.templateContent | striptags | truncate(200, true, "…") }}{% endset %}
+    {% endif %}
+    {% set hasHero = post.data.heroImage %}
+    <li class="blog-card{% if hasHero %} blog-card--with-image{% endif %}">
+      {% if hasHero %}
+      <a class="blog-card__image" href="{{ post.url | url }}">
+        <img src="{{ post.data.heroImage | url }}" alt="{{ post.data.heroAlt or (post.data.title ~ ' hero image') }}" loading="lazy" decoding="async">
+      </a>
       {% endif %}
+      <div class="blog-card__content">
+        <h2 class="blog-card__title">
+          <a href="{{ post.url | url }}">{{ post.data.title }}</a>
+        </h2>
+        {% if authorName or post.date %}
+        <p class="blog-card__meta">
+          {% if authorName %}
+          <span class="blog-card__author">{{ authorName }}</span>
+          {% endif %}
+          {% if authorName and post.date %}
+          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          {% endif %}
+          {% if post.date %}
+          <time class="blog-card__date" datetime="{{ post.date | isoDate }}">{{ post.date | date("MMMM d, yyyy") }}</time>
+          {% endif %}
+        </p>
+        {% endif %}
+        {% if summaryText %}
+        <p class="blog-card__excerpt">{{ summaryText }}</p>
+        {% endif %}
+        <a class="blog-card__read-more" href="{{ post.url | url }}">Read the article →</a>
+      </div>
     </li>
   {% endfor %}
 </ul>
-
-<nav aria-label="Pagination" style="margin-top:2rem;">
-  {% if pagination.href.previous %}
-    <a href="{{ pagination.href.previous }}">← Newer Posts</a>
-  {% endif %}
-  {% if pagination.href.next %}
-    <a href="{{ pagination.href.next }}" style="float:right;">Older Posts →</a>
-  {% endif %}
-</nav>
+{% else %}
+<p class="blog-list__empty">No posts available yet. Check back soon!</p>
+{% endif %}

--- a/blog-src/index.njk
+++ b/blog-src/index.njk
@@ -9,22 +9,16 @@ pagination:
 permalink: "{% if pagination.pageNumber == 0 %}index.html{% else %}page-{{ pagination.pageNumber + 1 }}/index.html{% endif %}"
 ---
 
-<h1>Blog</h1>
+<h1 class="blog-index__title">Blog</h1>
+<p class="blog-index__intro">Explore our newest guides, tutorials, and packing checklists for traveling light.</p>
 
-<ul>
-  {% for post in paged %}
-    <li>
-      <a href="{{ post.url }}">{{ post.data.title }}</a>
-      — {{ post.date | date("MMMM d, yyyy") }}
-    </li>
-  {% endfor %}
-</ul>
+{% include "blog-list.njk" %}
 
-<nav>
+<nav class="pagination" aria-label="Blog pagination">
   {% if pagination.href.previous %}
-    <a href="{{ pagination.href.previous | url }}">← Newer Posts</a>
+  <a class="pagination__link pagination__link--prev" href="{{ pagination.href.previous | url }}">← Newer Posts</a>
   {% endif %}
   {% if pagination.href.next %}
-    <a href="{{ pagination.href.next | url }}">Older Posts →</a>
+  <a class="pagination__link pagination__link--next" href="{{ pagination.href.next | url }}">Older Posts →</a>
   {% endif %}
 </nav>

--- a/blog-src/posts/avoid-overweight-baggage-fees-with-a-luggage-scale/index.md
+++ b/blog-src/posts/avoid-overweight-baggage-fees-with-a-luggage-scale/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Avoid Overweight Baggage Fees with a Luggage Scale"
 description: "A practical, airline‑agnostic guide to weigh bags at home and at the airport."
+author: "uPatch Travel Team"
+excerpt: "Step-by-step plan to weigh your suitcases ahead of travel so you skip surprise overweight fees."
+metaDescription: "Learn how to use a luggage scale to avoid overweight baggage fees with practical setup tips and repacking advice."
 date: 2025-09-11
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/business-travel-weekly-packing-system-to-eliminate-overages/index.md
+++ b/blog-src/posts/business-travel-weekly-packing-system-to-eliminate-overages/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Business Travel: Weekly Packing System to Eliminate Overages"
 description: "A repeatable workflow that keeps your roller under the limit."
+author: "uPatch Travel Team"
+excerpt: "Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress."
+metaDescription: "Create a business travel packing system that pairs a luggage scale with smart prep so you never pay overweight bag fees again."
 date: 2025-09-19
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/calibrate-verify-trusting-your-luggage-scale-s-readout/index.md
+++ b/blog-src/posts/calibrate-verify-trusting-your-luggage-scale-s-readout/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Calibrate & Verify: Trusting Your Luggage Scale’s Readout"
 description: "Sanity checks you can do at home to validate your scale’s accuracy."
+author: "uPatch Travel Team"
+excerpt: "Quick home calibration checks help you trust every luggage scale reading before you roll to the airport."
+metaDescription: "Use simple calibration tests and verification steps so you can rely on your luggage scale before leaving for the terminal."
 date: 2025-09-18
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/carry-on-weight-limits-what-to-know-always-check-your-airline/index.md
+++ b/blog-src/posts/carry-on-weight-limits-what-to-know-always-check-your-airline/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Carry‑On Weight Limits: What to Know (Always Check Your Airline)"
 description: "Overview of carry‑on weight considerations and how to stay under."
+author: "uPatch Travel Team"
+excerpt: "Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag."
+metaDescription: "Review carry-on baggage weight limits, airline differences, and simple luggage scale habits to stay compliant at the gate."
 date: 2025-09-13
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/family-travel-checklist-weigh-every-bag-in-2-minutes/index.md
+++ b/blog-src/posts/family-travel-checklist-weigh-every-bag-in-2-minutes/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Family Travel Checklist: Weigh Every Bag in 2 Minutes"
 description: "Fast routine to check all family luggage before leaving for the airport."
+author: "uPatch Travel Team"
+excerpt: "Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama."
+metaDescription: "Follow a family travel luggage checklist that uses a scale to verify every bag quickly before you head to the airport."
 date: 2025-09-16
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/hello-world/index.md
+++ b/blog-src/posts/hello-world/index.md
@@ -1,6 +1,9 @@
 ---
 title: Hello World — First Blog Post
 description: Testing the new blog setup.
+author: "uPatch Travel Team"
+excerpt: "A quick welcome post introducing the uPatch luggage scale blog and what we'll be sharing."
+metaDescription: "Meet the uPatch luggage scale blog—a short hello explaining the articles and travel tips coming soon."
 date: 2025-09-18
 ---
 

--- a/blog-src/posts/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.md
+++ b/blog-src/posts/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.md
@@ -1,6 +1,9 @@
 ---
 title: "How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale"
 description: "Step‑by‑step instructions for reliable readings without batteries."
+author: "uPatch Travel Team"
+excerpt: "Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip."
+metaDescription: "Learn the correct way to power, zero, and read a battery-free luggage scale so you capture accurate weights anywhere."
 date: 2025-09-12
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/international-vs-domestic-trips-planning-for-weight-differences/index.md
+++ b/blog-src/posts/international-vs-domestic-trips-planning-for-weight-differences/index.md
@@ -1,6 +1,9 @@
 ---
 title: "International vs. Domestic Trips: Planning for Weight Differences"
 description: "Key differences to consider and how a scale keeps you compliant."
+author: "uPatch Travel Team"
+excerpt: "Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures."
+metaDescription: "Compare international and domestic baggage weight limits and use a luggage scale to prepare for each itinerary with confidence."
 date: 2025-09-17
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.md
+++ b/blog-src/posts/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb"
 description: "Simple packing strategies to avoid check‑in surprises."
+author: "uPatch Travel Team"
+excerpt: "Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds."
+metaDescription: "Try ten practical packing tips plus luggage scale checkpoints to avoid overweight fees at airline check-in counters."
 date: 2025-09-14
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.md
+++ b/blog-src/posts/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)"
 description: "Techniques for accurate weighing when handles or shapes make it tricky."
+author: "uPatch Travel Team"
+excerpt: "Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits."
+metaDescription: "Get techniques for weighing strollers, golf bags, instruments, and other awkward gear accurately with a handheld luggage scale."
 date: 2025-09-15
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/posts/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.md
+++ b/blog-src/posts/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.md
@@ -1,6 +1,9 @@
 ---
 title: "Winter Gear Strategy: Coats, Boots, and Heavy Fabrics"
 description: "Keep weight under control when your wardrobe runs heavy."
+author: "uPatch Travel Team"
+excerpt: "Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing."
+metaDescription: "Use a luggage scale and smart packing strategy to manage winter gear weight so your cold-weather suitcase stays under the limit."
 date: 2025-09-20
 tags: ["luggage scale", "travel tips"]
 cluster: "travel"

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -139,3 +139,129 @@ img {
     padding: 1.5rem;
   }
 }
+
+/* Blog listing */
+.blog-index__title {
+  margin: 0 0 0.5rem;
+  font-size: 2.5rem;
+  line-height: 1.1;
+  color: #0f172a;
+}
+
+.blog-index__intro {
+  margin: 0 0 2rem;
+  font-size: 1.1rem;
+  color: #475569;
+}
+
+.blog-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.blog-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.25rem;
+  background-color: #ffffff;
+  border-radius: 0.75rem;
+  box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.08);
+  padding: 1.75rem;
+}
+
+.blog-card__image {
+  display: block;
+  border-radius: 0.65rem;
+  overflow: hidden;
+}
+
+.blog-card__image img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+}
+
+.blog-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.blog-card__title {
+  margin: 0;
+  font-size: 1.75rem;
+  line-height: 1.2;
+  color: #0f172a;
+}
+
+.blog-card__title a {
+  color: inherit;
+}
+
+.blog-card__meta {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.blog-card__excerpt {
+  margin: 0;
+  color: #334155;
+}
+
+.blog-card__read-more {
+  align-self: flex-start;
+  font-weight: 600;
+}
+
+.blog-list__empty {
+  font-style: italic;
+  color: #475569;
+}
+
+.pagination {
+  margin-top: 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pagination__link {
+  color: #1f7aec;
+  font-weight: 600;
+}
+
+.pagination__link--prev {
+  margin-right: auto;
+}
+
+.pagination__link--next {
+  margin-left: auto;
+}
+
+@media (min-width: 768px) {
+  .blog-card--with-image {
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.65fr);
+    align-items: center;
+  }
+
+  .blog-card--with-image .blog-card__image {
+    max-height: 14rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .blog-card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the blog list include with a reusable card layout that shows hero images, authors, formatted dates, and excerpt fallbacks
- update the blog index page to render the shared include and refresh pagination markup and intro copy
- add author/excerpt/metaDescription metadata to every post and extend blog styles for the new listing design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0abbf60108332ae02962fe031c71d