### PR TITLE
Refine blog typography and card utilities

### DIFF
--- a/blog-src/_includes/blog-list.njk
+++ b/blog-src/_includes/blog-list.njk
@@ -1,6 +1,6 @@
 {% set postsCollection = posts or paged or pagination.items or collections.posts %}
 {% if postsCollection and postsCollection | length %}
-<ul class="blog-list">
+<ul class="post-grid">
   {% for post in postsCollection %}
     {% set authorName = post.data.author or config.seo.defaultAuthor or "uPatch Travel Team" %}
     {% set summaryText = post.data.excerpt or post.data.metaDescription or post.data.description %}
@@ -8,34 +8,36 @@
       {% set summaryText %}{{ post.templateContent | striptags | truncate(200, true, "…") }}{% endset %}
     {% endif %}
     {% set hasHero = post.data.heroImage %}
-    <li class="blog-card{% if hasHero %} blog-card--with-image{% endif %}">
-      {% if hasHero %}
-      <a class="blog-card__image" href="{{ post.url | url }}">
-        <img src="{{ post.data.heroImage | url }}" alt="{{ post.data.heroAlt or (post.data.title ~ ' hero image') }}" loading="lazy" decoding="async">
-      </a>
-      {% endif %}
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="{{ post.url | url }}">{{ post.data.title }}</a>
-        </h2>
-        {% if authorName or post.date %}
-        <p class="blog-card__meta">
-          {% if authorName %}
-          <span class="blog-card__author">{{ authorName }}</span>
-          {% endif %}
-          {% if authorName and post.date %}
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
-          {% endif %}
-          {% if post.date %}
-          <time class="blog-card__date" datetime="{{ post.date | isoDate }}">{{ post.date | date("MMMM d, yyyy") }}</time>
-          {% endif %}
-        </p>
+    <li>
+      <article class="post-card{% if hasHero %} post-card--with-image{% endif %}">
+        {% if hasHero %}
+        <a class="post-card__media" href="{{ post.url | url }}">
+          <img src="{{ post.data.heroImage | url }}" alt="{{ post.data.heroAlt or (post.data.title ~ ' hero image') }}" loading="lazy" decoding="async">
+        </a>
         {% endif %}
-        {% if summaryText %}
-        <p class="blog-card__excerpt">{{ summaryText }}</p>
-        {% endif %}
-        <a class="blog-card__read-more" href="{{ post.url | url }}">Read the article →</a>
-      </div>
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="{{ post.url | url }}">{{ post.data.title }}</a>
+          </h2>
+          {% if authorName or post.date %}
+          <p class="post-meta">
+            {% if authorName %}
+            <span class="post-meta__author">{{ authorName }}</span>
+            {% endif %}
+            {% if authorName and post.date %}
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            {% endif %}
+            {% if post.date %}
+            <time class="post-meta__date" datetime="{{ post.date | isoDate }}">{{ post.date | date("MMMM d, yyyy") }}</time>
+            {% endif %}
+          </p>
+          {% endif %}
+          {% if summaryText %}
+          <p class="post-card__excerpt">{{ summaryText }}</p>
+          {% endif %}
+          <a class="post-card__cta" href="{{ post.url | url }}">Read the article →</a>
+        </div>
+      </article>
     </li>
   {% endfor %}
 </ul>

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -64,13 +64,13 @@
         {% if title %}
         <h1 class="post__title">{{ title }}</h1>
         {% endif %}
-        <div class="post__meta">
+        <div class="post-meta">
           {% if author %}
-          <span class="post__author">By {{ author }}</span>
+          <span class="post-meta__author">By {{ author }}</span>
           {% endif %}
           {% if date %}
-          {% if author %}<span class="post__meta-separator" aria-hidden="true">•</span>{% endif %}
-          <time class="post__date" datetime="{{ date | isoDate }}">{{ date | date("MMMM d, yyyy") }}</time>
+          {% if author %}<span class="post-meta__separator" aria-hidden="true">•</span>{% endif %}
+          <time class="post-meta__date" datetime="{{ date | isoDate }}">{{ date | date("MMMM d, yyyy") }}</time>
           {% endif %}
         </div>
         {% set summary = excerpt or description or config.seo.defaultDescription %}

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -1,20 +1,46 @@
-/* Blog global styles */
+/* Blog design tokens */
 :root {
   color-scheme: light dark;
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  --font-sans: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-text: #0f172a;
+  --color-muted: #64748b;
+  --color-subtle: #94a3b8;
+  --color-border: #e2e8f0;
+  --color-accent: #2563eb;
+  --shadow-xs: 0 4px 12px rgba(15, 23, 42, 0.04);
+  --shadow-sm: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --max-reading-width: 68ch;
+  --space-0: 0;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
 }
 
+/* Base layout */
 body {
   margin: 0;
-  padding: 0;
-  background-color: #f5f7fa;
-  color: #1f2933;
-  line-height: 1.6;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.65;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 a {
-  color: #0066cc;
+  color: var(--color-accent);
   text-decoration: none;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
 }
 
 a:hover,
@@ -22,222 +48,279 @@ a:focus {
   text-decoration: underline;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--radius-sm);
+}
+
+.container {
+  width: min(100% - 2.5rem, 62rem);
+  margin: 0 auto;
+}
+
 header,
 footer {
-  background: linear-gradient(135deg, #1f7aec, #45b6fe);
-  color: white;
-  padding: 1.5rem 1rem;
+  background: transparent;
+  color: var(--color-text);
+}
+
+header {
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-6);
+}
+
+footer {
+  padding: var(--space-5) 0;
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-8);
+  font-size: 0.95rem;
+  color: var(--color-muted);
 }
 
 main {
-  max-width: 60rem;
-  margin: 0 auto;
-  padding: 2rem 1rem;
+  padding: var(--space-6) 0;
 }
 
-article {
-  background-color: white;
-  border-radius: 0.75rem;
-  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
-  padding: 2rem;
-  margin-bottom: 2rem;
+@media (max-width: 640px) {
+  .container {
+    width: min(100% - 1.5rem, 60rem);
+  }
+
+  header {
+    margin-bottom: var(--space-5);
+  }
+
+  footer {
+    margin-top: var(--space-7);
+  }
+
+  main {
+    padding: var(--space-5) 0;
+  }
 }
 
-article h1,
-article h2,
-article h3 {
-  color: #0f172a;
+/* Typography */
+h1,
+h2,
+h3,
+h4 {
+  margin: 0 0 var(--space-3);
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--color-text);
 }
 
-.post__header {
-  margin-bottom: 2rem;
+h1,
+.heading-xl {
+  font-size: clamp(2.25rem, 5vw, 3rem);
 }
 
-.post__title {
-  margin: 0 0 0.5rem;
-  font-size: 2.25rem;
-  line-height: 1.1;
+h2,
+.heading-lg {
+  font-size: clamp(1.85rem, 3.5vw, 2.35rem);
 }
 
-.post__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  font-size: 0.95rem;
-  color: #475569;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+h3,
+.heading-md {
+  font-size: clamp(1.45rem, 2.5vw, 1.9rem);
 }
 
-.post__meta-separator {
-  color: #94a3b8;
+h4,
+.heading-sm {
+  font-size: 1.2rem;
 }
 
-.post__excerpt {
-  margin: 1.25rem 0 0;
-  padding: 1rem 1.25rem;
-  background-color: #f1f5f9;
-  border-left: 0.25rem solid #1f7aec;
-  border-radius: 0.5rem;
-  font-size: 1.1rem;
-  color: #1e293b;
+p {
+  margin: 0 0 var(--space-4);
 }
 
-.post__body {
-  font-size: 1.05rem;
+ul,
+ol {
+  margin: 0 0 var(--space-4);
+  padding-left: 1.35rem;
 }
 
-.post__body > :first-child {
-  margin-top: 0;
+hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-6) 0;
 }
 
-.post__body p {
-  margin-bottom: 1.25rem;
-}
-
-.post__disclaimer {
-  margin-top: 2.5rem;
-  padding: 1rem 1.25rem;
-  border-radius: 0.5rem;
-  background: #e0f2fe;
-  color: #0f172a;
-  font-size: 0.95rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+blockquote {
+  margin: var(--space-6) 0;
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--color-accent);
+  background-color: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-style: italic;
 }
 
 code,
 pre {
-  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  background-color: #0f172a0d;
+  font-family: var(--font-mono);
+  background-color: rgba(15, 23, 42, 0.05);
+}
+
+code {
+  padding: 0.15em 0.35em;
+  border-radius: 0.35rem;
 }
 
 pre {
   overflow-x: auto;
-  padding: 1rem;
-  border-radius: 0.5rem;
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
 }
 
-blockquote {
-  border-left: 0.25rem solid #45b6fe;
-  background-color: #e9f5ff;
-  padding: 0.75rem 1.25rem;
-  margin: 1.5rem 0;
+/* Utility spacing helpers */
+.stack-xs > * + * {
+  margin-top: var(--space-2);
 }
 
-img {
-  max-width: 100%;
-  border-radius: 0.5rem;
+.stack-sm > * + * {
+  margin-top: var(--space-3);
 }
 
-@media (max-width: 768px) {
-  main {
-    padding: 1.5rem 1rem;
-  }
+.stack-md > * + * {
+  margin-top: var(--space-4);
+}
 
-  article {
-    padding: 1.5rem;
-  }
+.stack-lg > * + * {
+  margin-top: var(--space-6);
+}
+
+.text-muted {
+  color: var(--color-muted);
 }
 
 /* Blog listing */
 .blog-index__title {
-  margin: 0 0 0.5rem;
-  font-size: 2.5rem;
-  line-height: 1.1;
-  color: #0f172a;
+  margin: 0 0 var(--space-2);
+  color: var(--color-text);
 }
 
 .blog-index__intro {
-  margin: 0 0 2rem;
-  font-size: 1.1rem;
-  color: #475569;
+  margin: 0 0 var(--space-6);
+  max-width: 60ch;
+  color: var(--color-muted);
 }
 
-.blog-list {
+.post-grid {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.75rem;
+  gap: var(--space-6);
 }
 
-.blog-card {
+.post-grid > li {
+  margin: 0;
+}
+
+.post-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(var(--space-5), 2vw + 1rem, var(--space-6));
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.25rem;
-  background-color: #ffffff;
-  border-radius: 0.75rem;
-  box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.08);
-  padding: 1.75rem;
+  gap: var(--space-5);
+  height: 100%;
 }
 
-.blog-card__image {
+.post-card--with-image {
+  align-items: center;
+}
+
+.post-card__media {
   display: block;
-  border-radius: 0.65rem;
+  border-radius: calc(var(--radius-md) - var(--space-1));
   overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background-color: rgba(148, 163, 184, 0.2);
 }
 
-.blog-card__image img {
+.post-card__media img {
   width: 100%;
-  height: auto;
-  display: block;
+  height: 100%;
   object-fit: cover;
 }
 
-.blog-card__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+.post-card__body {
+  display: grid;
+  gap: var(--space-4);
 }
 
-.blog-card__title {
+.post-card__title {
   margin: 0;
-  font-size: 1.75rem;
-  line-height: 1.2;
-  color: #0f172a;
+  font-size: clamp(1.65rem, 2.4vw, 2.05rem);
+  line-height: 1.25;
 }
 
-.blog-card__title a {
+.post-card__title a {
   color: inherit;
 }
 
-.blog-card__meta {
-  margin: 0;
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #64748b;
+.post-meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
 }
 
-.blog-card__excerpt {
+.post-meta__separator {
+  color: var(--color-subtle);
+}
+
+.post-card__excerpt {
   margin: 0;
-  color: #334155;
+  color: var(--color-text);
 }
 
-.blog-card__read-more {
-  align-self: flex-start;
+.post-card__cta {
   font-weight: 600;
+  color: var(--color-accent);
 }
 
-.blog-list__empty {
-  font-style: italic;
-  color: #475569;
+.post-card__cta:hover,
+.post-card__cta:focus {
+  text-decoration: underline;
 }
 
+@media (min-width: 768px) {
+  .post-card--with-image {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.45fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .post-card {
+    padding: var(--space-5);
+  }
+
+  .post-card--with-image {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* Pagination */
 .pagination {
-  margin-top: 2.5rem;
+  margin-top: var(--space-7);
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .pagination__link {
-  color: #1f7aec;
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -249,19 +332,66 @@ img {
   margin-left: auto;
 }
 
-@media (min-width: 768px) {
-  .blog-card--with-image {
-    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.65fr);
-    align-items: center;
-  }
+/* Post layout */
+.post {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(var(--space-6), 4vw + 1rem, var(--space-8));
+  display: grid;
+  gap: var(--space-6);
+}
 
-  .blog-card--with-image .blog-card__image {
-    max-height: 14rem;
-  }
+.post__header {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.post__title {
+  margin: 0;
+}
+
+.post__excerpt {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1.1rem;
+}
+
+.post__body {
+  display: grid;
+  gap: var(--space-4);
+  font-size: 1.05rem;
+  line-height: 1.75;
+  max-width: var(--max-reading-width);
+  width: 100%;
+  margin: 0 auto;
+}
+
+.post__body > * {
+  margin: 0;
+}
+
+.post__disclaimer {
+  margin: 0 auto;
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background-color: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+  font-size: 0.95rem;
+  max-width: var(--max-reading-width);
+  width: 100%;
 }
 
 @media (max-width: 600px) {
-  .blog-card {
-    padding: 1.25rem;
+  .post {
+    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-6));
   }
+}
+
+/* Empty state */
+.blog-list__empty {
+  font-style: italic;
+  color: var(--color-muted);
 }

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Avoid Overweight Baggage Fees with a Luggage Scale</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-11">September 11, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-11">September 11, 2025</time>
           
         </div>
         

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Business Travel: Weekly Packing System to Eliminate Overages</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-19">September 19, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-19">September 19, 2025</time>
           
         </div>
         

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-18">September 18, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
           
         </div>
         

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-13">September 13, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-13">September 13, 2025</time>
           
         </div>
         

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Family Travel Checklist: Weigh Every Bag in 2 Minutes</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-16">September 16, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-16">September 16, 2025</time>
           
         </div>
         

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Hello World — First Blog Post</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-18">September 18, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
           
         </div>
         

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-12">September 12, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-12">September 12, 2025</time>
           
         </div>
         

--- a/blog/index.html
+++ b/blog/index.html
@@ -116,306 +116,326 @@
 
 
 
-<ul class="blog-list">
+<ul class="post-grid">
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-20">September 20, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-20">September 20, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Business Travel: Weekly Packing System to Eliminate Overages</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Business Travel: Weekly Packing System to Eliminate Overages</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-19">September 19, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-19">September 19, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-18">September 18, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/hello-world/">Hello World — First Blog Post</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/hello-world/">Hello World — First Blog Post</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">A quick welcome post introducing the uPatch luggage scale blog and what we&#39;ll be sharing.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-18">September 18, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">A quick welcome post introducing the uPatch luggage scale blog and what we&#39;ll be sharing.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/hello-world/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/hello-world/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/international-vs-domestic-trips-planning-for-weight-differences/">International vs. Domestic Trips: Planning for Weight Differences</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/international-vs-domestic-trips-planning-for-weight-differences/">International vs. Domestic Trips: Planning for Weight Differences</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-17">September 17, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-17">September 17, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/international-vs-domestic-trips-planning-for-weight-differences/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/international-vs-domestic-trips-planning-for-weight-differences/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Family Travel Checklist: Weigh Every Bag in 2 Minutes</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Family Travel Checklist: Weigh Every Bag in 2 Minutes</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-16">September 16, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-16">September 16, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-15">September 15, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-15">September 15, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-14">September 14, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-14">September 14, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-13">September 13, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-13">September 13, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-12">September 12, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-12">September 12, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
 </ul>

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">International vs. Domestic Trips: Planning for Weight Differences</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-17">September 17, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-17">September 17, 2025</time>
           
         </div>
         

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-14">September 14, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-14">September 14, 2025</time>
           
         </div>
         

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -116,36 +116,38 @@
 
 
 
-<ul class="blog-list">
+<ul class="post-grid">
   
     
     
     
     
-    <li class="blog-card">
-      
-      <div class="blog-card__content">
-        <h2 class="blog-card__title">
-          <a href="/blog/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Avoid Overweight Baggage Fees with a Luggage Scale</a>
-        </h2>
+    <li>
+      <article class="post-card">
         
-        <p class="blog-card__meta">
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Avoid Overweight Baggage Fees with a Luggage Scale</a>
+          </h2>
           
-          <span class="blog-card__author">uPatch Travel Team</span>
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-11">September 11, 2025</time>
+            
+          </p>
           
           
-          <span class="blog-card__meta-separator" aria-hidden="true">•</span>
+          <p class="post-card__excerpt">Step-by-step plan to weigh your suitcases ahead of travel so you skip surprise overweight fees.</p>
           
-          
-          <time class="blog-card__date" datetime="2025-09-11">September 11, 2025</time>
-          
-        </p>
-        
-        
-        <p class="blog-card__excerpt">Step-by-step plan to weigh your suitcases ahead of travel so you skip surprise overweight fees.</p>
-        
-        <a class="blog-card__read-more" href="/blog/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Read the article →</a>
-      </div>
+          <a class="post-card__cta" href="/blog/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Read the article →</a>
+        </div>
+      </article>
     </li>
   
 </ul>

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1,20 +1,46 @@
-/* Blog global styles */
+/* Blog design tokens */
 :root {
   color-scheme: light dark;
-  font-family: "Helvetica Neue", Arial, sans-serif;
+  --font-sans: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --color-bg: #f8fafc;
+  --color-surface: #ffffff;
+  --color-text: #0f172a;
+  --color-muted: #64748b;
+  --color-subtle: #94a3b8;
+  --color-border: #e2e8f0;
+  --color-accent: #2563eb;
+  --shadow-xs: 0 4px 12px rgba(15, 23, 42, 0.04);
+  --shadow-sm: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --max-reading-width: 68ch;
+  --space-0: 0;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
 }
 
+/* Base layout */
 body {
   margin: 0;
-  padding: 0;
-  background-color: #f5f7fa;
-  color: #1f2933;
-  line-height: 1.6;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.65;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 a {
-  color: #0066cc;
+  color: var(--color-accent);
   text-decoration: none;
+  transition: color 150ms ease, text-decoration-color 150ms ease;
 }
 
 a:hover,
@@ -22,222 +48,279 @@ a:focus {
   text-decoration: underline;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--radius-sm);
+}
+
+.container {
+  width: min(100% - 2.5rem, 62rem);
+  margin: 0 auto;
+}
+
 header,
 footer {
-  background: linear-gradient(135deg, #1f7aec, #45b6fe);
-  color: white;
-  padding: 1.5rem 1rem;
+  background: transparent;
+  color: var(--color-text);
+}
+
+header {
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-6);
+}
+
+footer {
+  padding: var(--space-5) 0;
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-8);
+  font-size: 0.95rem;
+  color: var(--color-muted);
 }
 
 main {
-  max-width: 60rem;
-  margin: 0 auto;
-  padding: 2rem 1rem;
+  padding: var(--space-6) 0;
 }
 
-article {
-  background-color: white;
-  border-radius: 0.75rem;
-  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
-  padding: 2rem;
-  margin-bottom: 2rem;
+@media (max-width: 640px) {
+  .container {
+    width: min(100% - 1.5rem, 60rem);
+  }
+
+  header {
+    margin-bottom: var(--space-5);
+  }
+
+  footer {
+    margin-top: var(--space-7);
+  }
+
+  main {
+    padding: var(--space-5) 0;
+  }
 }
 
-article h1,
-article h2,
-article h3 {
-  color: #0f172a;
+/* Typography */
+h1,
+h2,
+h3,
+h4 {
+  margin: 0 0 var(--space-3);
+  font-weight: 600;
+  line-height: 1.15;
+  color: var(--color-text);
 }
 
-.post__header {
-  margin-bottom: 2rem;
+h1,
+.heading-xl {
+  font-size: clamp(2.25rem, 5vw, 3rem);
 }
 
-.post__title {
-  margin: 0 0 0.5rem;
-  font-size: 2.25rem;
-  line-height: 1.1;
+h2,
+.heading-lg {
+  font-size: clamp(1.85rem, 3.5vw, 2.35rem);
 }
 
-.post__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  font-size: 0.95rem;
-  color: #475569;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+h3,
+.heading-md {
+  font-size: clamp(1.45rem, 2.5vw, 1.9rem);
 }
 
-.post__meta-separator {
-  color: #94a3b8;
+h4,
+.heading-sm {
+  font-size: 1.2rem;
 }
 
-.post__excerpt {
-  margin: 1.25rem 0 0;
-  padding: 1rem 1.25rem;
-  background-color: #f1f5f9;
-  border-left: 0.25rem solid #1f7aec;
-  border-radius: 0.5rem;
-  font-size: 1.1rem;
-  color: #1e293b;
+p {
+  margin: 0 0 var(--space-4);
 }
 
-.post__body {
-  font-size: 1.05rem;
+ul,
+ol {
+  margin: 0 0 var(--space-4);
+  padding-left: 1.35rem;
 }
 
-.post__body > :first-child {
-  margin-top: 0;
+hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-6) 0;
 }
 
-.post__body p {
-  margin-bottom: 1.25rem;
-}
-
-.post__disclaimer {
-  margin-top: 2.5rem;
-  padding: 1rem 1.25rem;
-  border-radius: 0.5rem;
-  background: #e0f2fe;
-  color: #0f172a;
-  font-size: 0.95rem;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+blockquote {
+  margin: var(--space-6) 0;
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--color-accent);
+  background-color: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-style: italic;
 }
 
 code,
 pre {
-  font-family: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  background-color: #0f172a0d;
+  font-family: var(--font-mono);
+  background-color: rgba(15, 23, 42, 0.05);
+}
+
+code {
+  padding: 0.15em 0.35em;
+  border-radius: 0.35rem;
 }
 
 pre {
   overflow-x: auto;
-  padding: 1rem;
-  border-radius: 0.5rem;
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
 }
 
-blockquote {
-  border-left: 0.25rem solid #45b6fe;
-  background-color: #e9f5ff;
-  padding: 0.75rem 1.25rem;
-  margin: 1.5rem 0;
+/* Utility spacing helpers */
+.stack-xs > * + * {
+  margin-top: var(--space-2);
 }
 
-img {
-  max-width: 100%;
-  border-radius: 0.5rem;
+.stack-sm > * + * {
+  margin-top: var(--space-3);
 }
 
-@media (max-width: 768px) {
-  main {
-    padding: 1.5rem 1rem;
-  }
+.stack-md > * + * {
+  margin-top: var(--space-4);
+}
 
-  article {
-    padding: 1.5rem;
-  }
+.stack-lg > * + * {
+  margin-top: var(--space-6);
+}
+
+.text-muted {
+  color: var(--color-muted);
 }
 
 /* Blog listing */
 .blog-index__title {
-  margin: 0 0 0.5rem;
-  font-size: 2.5rem;
-  line-height: 1.1;
-  color: #0f172a;
+  margin: 0 0 var(--space-2);
+  color: var(--color-text);
 }
 
 .blog-index__intro {
-  margin: 0 0 2rem;
-  font-size: 1.1rem;
-  color: #475569;
+  margin: 0 0 var(--space-6);
+  max-width: 60ch;
+  color: var(--color-muted);
 }
 
-.blog-list {
+.post-grid {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.75rem;
+  gap: var(--space-6);
 }
 
-.blog-card {
+.post-grid > li {
+  margin: 0;
+}
+
+.post-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(var(--space-5), 2vw + 1rem, var(--space-6));
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.25rem;
-  background-color: #ffffff;
-  border-radius: 0.75rem;
-  box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.08);
-  padding: 1.75rem;
+  gap: var(--space-5);
+  height: 100%;
 }
 
-.blog-card__image {
+.post-card--with-image {
+  align-items: center;
+}
+
+.post-card__media {
   display: block;
-  border-radius: 0.65rem;
+  border-radius: calc(var(--radius-md) - var(--space-1));
   overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background-color: rgba(148, 163, 184, 0.2);
 }
 
-.blog-card__image img {
+.post-card__media img {
   width: 100%;
-  height: auto;
-  display: block;
+  height: 100%;
   object-fit: cover;
 }
 
-.blog-card__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+.post-card__body {
+  display: grid;
+  gap: var(--space-4);
 }
 
-.blog-card__title {
+.post-card__title {
   margin: 0;
-  font-size: 1.75rem;
-  line-height: 1.2;
-  color: #0f172a;
+  font-size: clamp(1.65rem, 2.4vw, 2.05rem);
+  line-height: 1.25;
 }
 
-.blog-card__title a {
+.post-card__title a {
   color: inherit;
 }
 
-.blog-card__meta {
-  margin: 0;
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #64748b;
+.post-meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-muted);
 }
 
-.blog-card__excerpt {
+.post-meta__separator {
+  color: var(--color-subtle);
+}
+
+.post-card__excerpt {
   margin: 0;
-  color: #334155;
+  color: var(--color-text);
 }
 
-.blog-card__read-more {
-  align-self: flex-start;
+.post-card__cta {
   font-weight: 600;
+  color: var(--color-accent);
 }
 
-.blog-list__empty {
-  font-style: italic;
-  color: #475569;
+.post-card__cta:hover,
+.post-card__cta:focus {
+  text-decoration: underline;
 }
 
+@media (min-width: 768px) {
+  .post-card--with-image {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.45fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .post-card {
+    padding: var(--space-5);
+  }
+
+  .post-card--with-image {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* Pagination */
 .pagination {
-  margin-top: 2.5rem;
+  margin-top: var(--space-7);
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .pagination__link {
-  color: #1f7aec;
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -249,19 +332,66 @@ img {
   margin-left: auto;
 }
 
-@media (min-width: 768px) {
-  .blog-card--with-image {
-    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.65fr);
-    align-items: center;
-  }
+/* Post layout */
+.post {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(var(--space-6), 4vw + 1rem, var(--space-8));
+  display: grid;
+  gap: var(--space-6);
+}
 
-  .blog-card--with-image .blog-card__image {
-    max-height: 14rem;
-  }
+.post__header {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.post__title {
+  margin: 0;
+}
+
+.post__excerpt {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1.1rem;
+}
+
+.post__body {
+  display: grid;
+  gap: var(--space-4);
+  font-size: 1.05rem;
+  line-height: 1.75;
+  max-width: var(--max-reading-width);
+  width: 100%;
+  margin: 0 auto;
+}
+
+.post__body > * {
+  margin: 0;
+}
+
+.post__disclaimer {
+  margin: 0 auto;
+  padding: var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background-color: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+  font-size: 0.95rem;
+  max-width: var(--max-reading-width);
+  width: 100%;
 }
 
 @media (max-width: 600px) {
-  .blog-card {
-    padding: 1.25rem;
+  .post {
+    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-6));
   }
+}
+
+/* Empty state */
+.blog-list__empty {
+  font-style: italic;
+  color: var(--color-muted);
 }

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-15">September 15, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-15">September 15, 2025</time>
           
         </div>
         

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -118,13 +118,13 @@
         
         <h1 class="post__title">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</h1>
         
-        <div class="post__meta">
+        <div class="post-meta">
           
-          <span class="post__author">By uPatch Travel Team</span>
+          <span class="post-meta__author">By uPatch Travel Team</span>
           
           
-          <span class="post__meta-separator" aria-hidden="true">•</span>
-          <time class="post__date" datetime="2025-09-20">September 20, 2025</time>
+          <span class="post-meta__separator" aria-hidden="true">•</span>
+          <time class="post-meta__date" datetime="2025-09-20">September 20, 2025</time>
           
         </div>
         


### PR DESCRIPTION
## Summary
- add design tokens, spacing helpers, and minimal typography/card utilities to the shared blog stylesheet
- update the blog listing template to use the new post card and metadata classes
- refresh the post layout markup so articles pick up the improved meta styling and typography scale

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0ad61cbe48332878e5e34cd738bae