### PR TITLE
Add analytics toggles and Amazon affiliate helpers

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 // .eleventy.js
 const { DateTime } = require("luxon");
+const siteConfig = require("./blog-src/_data/config.json");
 
 /** Normalize different date inputs to a JS Date. */
 function toJsDate(value) {
@@ -8,6 +9,83 @@ function toJsDate(value) {
   const parsed = new Date(value);
   if (!isNaN(parsed)) return parsed;
   return new Date();
+}
+
+function escapeHtml(value) {
+  if (value === undefined || value === null) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function buildAmazonLink(productId, textOverride) {
+  const affiliate = (siteConfig.affiliate && siteConfig.affiliate.amazon) || {};
+  if (!affiliate.products) {
+    return "<!-- Amazon affiliate configuration missing -->";
+  }
+
+  const resolvedId =
+    typeof productId === "string"
+      ? productId
+      : productId && (productId.id || productId.asin || productId.sku);
+  if (!resolvedId) {
+    return "<!-- Amazon affiliate product id missing -->";
+  }
+
+  const product = affiliate.products[resolvedId];
+  if (!product) {
+    return `<!-- Amazon affiliate product not found: ${escapeHtml(resolvedId)} -->`;
+  }
+
+  const asin = product.asin || resolvedId;
+  const baseDomain = product.domain || affiliate.defaultDomain || "com";
+  const defaultPath = product.path || `dp/${asin}`;
+  const baseUrl = product.url || `https://www.amazon.${baseDomain}/${defaultPath}`;
+
+  const params = new URLSearchParams();
+  if (affiliate.tag) {
+    params.set("tag", affiliate.tag);
+  }
+  const defaultQuery = affiliate.defaultQuery || {};
+  const productQuery = product.query || {};
+  for (const [key, value] of Object.entries({ ...defaultQuery, ...productQuery })) {
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, value);
+    }
+  }
+
+  const queryString = params.toString();
+  const url = queryString
+    ? `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}${queryString}`
+    : baseUrl;
+
+  const linkText =
+    textOverride || product.text || affiliate.defaultText || "View this item on Amazon";
+  const linkTitle = product.title || linkText;
+  const classNames = [affiliate.defaultClass, product.className]
+    .filter(Boolean)
+    .join(" ");
+
+  const attributes = [
+    `href="${escapeHtml(url)}"`,
+    "rel=\"sponsored noopener noreferrer\"",
+    "target=\"_blank\"",
+    "data-affiliate=\"amazon\"",
+  ];
+  if (asin) {
+    attributes.push(`data-asin=\"${escapeHtml(asin)}\"`);
+  }
+  if (classNames) {
+    attributes.push(`class=\"${escapeHtml(classNames)}\"`);
+  }
+  if (linkTitle) {
+    attributes.push(`title=\"${escapeHtml(linkTitle)}\"`);
+  }
+
+  return `<a ${attributes.join(" ")}>${escapeHtml(linkText)}</a>`;
 }
 
 module.exports = function (eleventyConfig) {
@@ -20,6 +98,12 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("isoDate", (value) =>
     DateTime.fromJSDate(toJsDate(value), { zone: "utc" }).toISODate()
   );
+
+  const amazonLinkHelper = (productId, textOverride) =>
+    buildAmazonLink(productId, textOverride);
+
+  eleventyConfig.addFilter("amazonLink", amazonLinkHelper);
+  eleventyConfig.addShortcode("amazonLink", amazonLinkHelper);
 
   // Build absolute URLs safely; ensure site.base (e.g., /blog) is present
   // Expects config.site like: { "url": "https://luggage-scale.com", "base": "/blog" }

--- a/blog-src/_data/config.json
+++ b/blog-src/_data/config.json
@@ -14,5 +14,37 @@
     "defaultOgType": "website",
     "defaultTwitterCard": "summary_large_image",
     "defaultAuthor": "uPatch Travel Team"
+  },
+  "integrations": {
+    "analytics": {
+      "googleAnalyticsId": "G-XXXXXXX",
+      "plausible": {
+        "domain": "luggage-scale.com",
+        "script": "https://plausible.io/js/script.js",
+        "apiHost": "https://plausible.io"
+      }
+    },
+    "adsense": {
+      "clientId": "ca-pub-1234567890123456"
+    }
+  },
+  "affiliate": {
+    "amazon": {
+      "tag": "luggagescale-20",
+      "defaultDomain": "com",
+      "defaultText": "See the latest price on Amazon",
+      "products": {
+        "upatch-digital-scale": {
+          "asin": "B0AUPATCH01",
+          "title": "uPatch Digital Hanging Luggage Scale",
+          "text": "Shop the uPatch luggage scale on Amazon"
+        },
+        "travel-compression-cubes": {
+          "asin": "B0BCUBESET1",
+          "title": "Compression Packing Cubes Set",
+          "text": "Grab the compression cubes on Amazon"
+        }
+      }
+    }
   }
 }

--- a/blog-src/_data/env.js
+++ b/blog-src/_data/env.js
@@ -1,0 +1,4 @@
+module.exports = {
+  analytics: process.env.ENABLE_ANALYTICS === "true",
+  adsense: process.env.ENABLE_ADSENSE === "true",
+};

--- a/blog-src/_includes/head.njk
+++ b/blog-src/_includes/head.njk
@@ -10,6 +10,10 @@
   "logoPath": config.site.logoPath
 } %}
 {% set seoDefaults = config.seo or {} %}
+{% set integrations = config.integrations or {} %}
+{% set analyticsConfig = integrations.analytics or {} %}
+{% set adsenseConfig = integrations.adsense or {} %}
+{% set envFlags = env or {} %}
 
 {% set computedMetaTitle = metaTitle or seoDefaults.defaultTitle or headSite.name %}
 {% set computedMetaDescription = metaDescription or seoDefaults.defaultDescription %}
@@ -81,4 +85,34 @@
   {% if modifiedDate %}
   <meta property="article:modified_time" content="{{ modifiedDate | isoDate }}">
   {% endif %}
+{% endif %}
+{% if envFlags.analytics %}
+  {% if analyticsConfig.googleAnalyticsId %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ analyticsConfig.googleAnalyticsId }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '{{ analyticsConfig.googleAnalyticsId }}', {
+        'page_path': '{{ (page.url or '/') | replace("'", "\\'") }}',
+        'anonymize_ip': true
+      });
+    </script>
+  {% endif %}
+  {% if analyticsConfig.plausible and analyticsConfig.plausible.domain %}
+    <script
+      defer
+      data-domain="{{ analyticsConfig.plausible.domain }}"
+      src="{{ analyticsConfig.plausible.script or 'https://plausible.io/js/script.js' }}"
+      {% if analyticsConfig.plausible.apiHost %}data-api="{{ analyticsConfig.plausible.apiHost }}/api/event"{% endif %}
+    ></script>
+  {% endif %}
+{% endif %}
+{% if envFlags.adsense and adsenseConfig.clientId %}
+  <meta name="google-adsense-account" content="{{ adsenseConfig.clientId }}">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ adsenseConfig.clientId }}" crossorigin="anonymous"></script>
+  <!-- Google AdSense placeholder -->
+  <script>
+    window.adsbygoogle = window.adsbygoogle || [];
+  </script>
 {% endif %}

--- a/blog-src/posts/hello-world/index.md
+++ b/blog-src/posts/hello-world/index.md
@@ -9,6 +9,16 @@ date: 2025-09-18
 
 This is your **first test post** in the new blog system.
 
-- Written in Markdown  
-- Stored in `/blog-src/posts/hello-world/index.md`  
+- Written in Markdown
+- Stored in `/blog-src/posts/hello-world/index.md`
 - When built, it will publish to `/blog/hello-world/`
+
+## Affiliate picks
+
+Want to try the gear we mention? Start with our go-to travel scale:
+
+{% amazonLink "upatch-digital-scale" %}
+
+Need help staying organized? {{ "travel-compression-cubes" | amazonLink("Compression packing cubes on Amazon") }}
+
+<small>As an Amazon Associate we earn from qualifying purchases.</small>


### PR DESCRIPTION
## Summary
- inject Google Analytics, Plausible, and AdSense resources in the shared head template only when the new environment flags are enabled
- add reusable amazonLink shortcode/filter backed by affiliate product metadata so posts can render consistent Amazon CTAs
- extend the site config and sample "Hello World" post to demonstrate the new affiliate helper and expose marketing IDs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b0fc9d3483329317c1e89289c1c9