### PR TITLE
Normalize first post heading to avoid duplicate h1 tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -105,6 +105,53 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("amazonLink", amazonLinkHelper);
   eleventyConfig.addShortcode("amazonLink", amazonLinkHelper);
 
+  eleventyConfig.addFilter("normalizePostHeadings", (content, pageTitle) => {
+    if (!content) return content;
+
+    const html = String(content);
+    const firstHeadingMatch = html.match(/^[\s\uFEFF\xA0]*<h1[^>]*>([\s\S]*?)<\/h1>[\s\uFEFF\xA0]*/i);
+
+    if (!firstHeadingMatch) {
+      return html;
+    }
+
+    const [fullMatch, innerHtml] = firstHeadingMatch;
+
+    const decodeHtmlEntities = (value) =>
+      value
+        .replace(/&amp;/gi, "&")
+        .replace(/&lt;/gi, "<")
+        .replace(/&gt;/gi, ">")
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;/gi, "'");
+
+    const normalizeText = (value) =>
+      decodeHtmlEntities(String(value || ""))
+        .replace(/<[^>]*>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+
+    const normalizedHeading = normalizeText(innerHtml);
+    const normalizedTitle = normalizeText(pageTitle);
+
+    if (normalizedTitle && normalizedHeading && normalizedHeading === normalizedTitle) {
+      return html.replace(fullMatch, "");
+    }
+
+    const leadingWhitespace = fullMatch.match(/^[\s\uFEFF\xA0]*/)[0];
+    const trailingWhitespace = fullMatch.match(/[\s\uFEFF\xA0]*$/)[0];
+    const headingMarkup = fullMatch.slice(
+      leadingWhitespace.length,
+      fullMatch.length - trailingWhitespace.length
+    );
+
+    const demotedHeading = headingMarkup
+      .replace(/<h1/gi, "<h2")
+      .replace(/<\/h1>/gi, "</h2>");
+
+    return html.replace(fullMatch, `${leadingWhitespace}${demotedHeading}${trailingWhitespace}`);
+  });
+
   // Build absolute URLs safely; ensure site.base (e.g., /blog) is present
   // Expects config.site like: { "url": "https://luggage-scale.com", "base": "/blog" }
   eleventyConfig.addFilter("absoluteUrl", (path, site) => {

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -80,7 +80,7 @@
       </header>
 
       <div class="post__body">
-        {{ content | safe }}
+        {{ content | normalizePostHeadings(title) | safe }}
       </div>
 
       {% if affiliateDisclaimer %}

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Avoid Overweight Baggage Fees with a Luggage Scale</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Business Travel: Weekly Packing System to Eliminate Overages</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Carry‑On Weight Limits: What to Know (Always Check Your Airline)</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Family Travel Checklist: Weigh Every Bag in 2 Minutes</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>International vs. Domestic Trips: Planning for Weight Differences</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -140,8 +140,7 @@
       </header>
 
       <div class="post__body">
-        <h1>Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</h1>
-<p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
 <h2>Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
 <h2>What you’ll need</h2>


### PR DESCRIPTION
## Summary
- add an Eleventy filter that removes or demotes the first H1 generated from post content
- apply the filter in the post layout so the template-provided title is the only H1
- rebuild the generated blog output with the updated heading structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b8defb8c8332ae11d3603d0c8b53