### PR TITLE
Make blog post grid responsive

### DIFF
--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -214,11 +214,18 @@ pre {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: var(--space-6);
+  gap: clamp(var(--space-5), 3vw, var(--space-6));
+  grid-template-columns: 1fr;
 }
 
 .post-grid > li {
   margin: 0;
+}
+
+@media (min-width: 40rem) {
+  .post-grid {
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  }
 }
 
 .post-card {

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -214,11 +214,18 @@ pre {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: var(--space-6);
+  gap: clamp(var(--space-5), 3vw, var(--space-6));
+  grid-template-columns: 1fr;
 }
 
 .post-grid > li {
   margin: 0;
+}
+
+@media (min-width: 40rem) {
+  .post-grid {
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+  }
 }
 
 .post-card {


### PR DESCRIPTION
## Summary
- update the blog post grid styles to support responsive multi-column layouts with flexible gaps
- add a media query so larger viewports use an auto-fitting grid while small screens collapse to a single column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b9b893588332b102fa9f30b7d059