### PR TITLE
Revise blog styles to use brand palette

### DIFF
--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1,17 +1,17 @@
 /* Blog design tokens */
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
   --font-sans: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --color-bg: #f8fafc;
-  --color-surface: #ffffff;
-  --color-text: #0f172a;
-  --color-muted: #64748b;
-  --color-subtle: #94a3b8;
-  --color-border: #e2e8f0;
-  --color-accent: #2563eb;
-  --shadow-xs: 0 4px 12px rgba(15, 23, 42, 0.04);
-  --shadow-sm: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --color-bg: #0a1a2f;
+  --color-surface: #11294d;
+  --color-text: #f0f8ff;
+  --color-muted: #c5d6eb;
+  --color-subtle: #8fb0d3;
+  --color-border: #1c365b;
+  --color-accent: #4db8ff;
+  --shadow-xs: 0 6px 18px rgba(3, 12, 26, 0.3);
+  --shadow-sm: 0 26px 60px rgba(3, 12, 26, 0.45);
   --radius-sm: 0.5rem;
   --radius-md: 0.75rem;
   --max-reading-width: 68ch;
@@ -60,24 +60,22 @@ img {
   margin: 0 auto;
 }
 
-header,
-footer {
-  background: transparent;
-  color: var(--color-text);
-}
-
 header {
+  background-color: var(--color-surface);
   padding: var(--space-4) 0;
   border-bottom: 1px solid var(--color-border);
   margin-bottom: var(--space-6);
+  box-shadow: var(--shadow-xs);
 }
 
 footer {
+  background-color: var(--color-surface);
   padding: var(--space-5) 0;
   border-top: 1px solid var(--color-border);
   margin-top: var(--space-8);
   font-size: 0.95rem;
   color: var(--color-muted);
+  box-shadow: var(--shadow-xs);
 }
 
 main {
@@ -153,7 +151,7 @@ blockquote {
   margin: var(--space-6) 0;
   padding: var(--space-3) var(--space-4);
   border-left: 3px solid var(--color-accent);
-  background-color: rgba(37, 99, 235, 0.08);
+  background-color: rgba(77, 184, 255, 0.16);
   color: var(--color-text);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   font-style: italic;
@@ -162,18 +160,21 @@ blockquote {
 code,
 pre {
   font-family: var(--font-mono);
-  background-color: rgba(15, 23, 42, 0.05);
+  background-color: rgba(77, 184, 255, 0.08);
+  color: var(--color-text);
 }
 
 code {
   padding: 0.15em 0.35em;
   border-radius: 0.35rem;
+  border: 1px solid var(--color-border);
 }
 
 pre {
   overflow-x: auto;
   padding: var(--space-3);
   border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
 }
 
 /* Utility spacing helpers */
@@ -237,6 +238,7 @@ pre {
   display: grid;
   gap: var(--space-5);
   height: 100%;
+  color: var(--color-text);
 }
 
 .post-card--with-image {
@@ -248,7 +250,7 @@ pre {
   border-radius: calc(var(--radius-md) - var(--space-1));
   overflow: hidden;
   aspect-ratio: 16 / 9;
-  background-color: rgba(148, 163, 184, 0.2);
+  background-color: rgba(77, 184, 255, 0.12);
 }
 
 .post-card__media img {
@@ -280,7 +282,7 @@ pre {
   font-size: 0.9rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: var(--color-subtle);
 }
 
 .post-meta__separator {
@@ -289,7 +291,7 @@ pre {
 
 .post-card__excerpt {
   margin: 0;
-  color: var(--color-text);
+  color: var(--color-muted);
 }
 
 .post-card__cta {
@@ -348,6 +350,7 @@ pre {
   padding: clamp(var(--space-6), 4vw + 1rem, var(--space-8));
   display: grid;
   gap: var(--space-6);
+  color: var(--color-text);
 }
 
 .post__header {
@@ -383,8 +386,8 @@ pre {
   margin: 0 auto;
   padding: var(--space-4);
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background-color: rgba(37, 99, 235, 0.08);
+  border: 1px solid var(--color-border);
+  background-color: rgba(77, 184, 255, 0.12);
   color: var(--color-text);
   font-size: 0.95rem;
   max-width: var(--max-reading-width);


### PR DESCRIPTION
## Summary
- align the blog color tokens with the brand palette for background, surface, text, and accent shades
- apply the new design tokens to the layout chrome so the header, footer, and body share the refreshed look and feel
- refresh card, code, and callout treatments to ensure contrast and readability on the darker theme

## Testing
- not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68d0bba4606883328e298e650a67843e