### PR TITLE
Add inline SVG icons to blog index

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -138,20 +138,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-20">September 20, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-20">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 20, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.</p>
           
-          <a class="post-card__cta" href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -170,20 +188,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-19">September 19, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-19">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 19, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.</p>
           
-          <a class="post-card__cta" href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -202,20 +238,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-18">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 18, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.</p>
           
-          <a class="post-card__cta" href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -234,20 +288,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-18">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 18, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">A quick welcome post introducing the uPatch luggage scale blog and what we&#39;ll be sharing.</p>
           
-          <a class="post-card__cta" href="/blog/hello-world/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/hello-world/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -266,20 +338,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-17">September 17, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-17">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 17, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.</p>
           
-          <a class="post-card__cta" href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -298,20 +388,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-16">September 16, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-16">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 16, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.</p>
           
-          <a class="post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -330,20 +438,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-15">September 15, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-15">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 15, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
           
-          <a class="post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -362,20 +488,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-14">September 14, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-14">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 14, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.</p>
           
-          <a class="post-card__cta" href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -394,20 +538,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-13">September 13, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-13">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 13, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.</p>
           
-          <a class="post-card__cta" href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>
@@ -426,20 +588,38 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">uPatch Travel Team</span>
+            <span class="post-meta__author">
+              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
+                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              uPatch Travel Team
+            </span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-12">September 12, 2025</time>
+            <time class="post-meta__date" datetime="2025-09-12">
+              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
+                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              September 12, 2025
+            </time>
             
           </p>
           
           
           <p class="post-card__excerpt">Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.</p>
           
-          <a class="post-card__cta" href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">Read the article →</a>
+          <a class="post-card__cta" href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
+            Read the article
+            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
         </div>
       </article>
     </li>

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -48,6 +48,23 @@ a:focus {
   text-decoration: underline;
 }
 
+.icon {
+  width: 1.1em;
+  height: 1.1em;
+  display: inline-block;
+  flex-shrink: 0;
+  color: var(--color-accent);
+  vertical-align: middle;
+}
+
+.icon path,
+.icon rect,
+.icon circle,
+.icon line,
+.icon polyline {
+  vector-effect: non-scaling-stroke;
+}
+
 img {
   max-width: 100%;
   height: auto;
@@ -285,6 +302,13 @@ pre {
   color: var(--color-subtle);
 }
 
+.post-meta__author,
+.post-meta__date {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
 .post-meta__separator {
   color: var(--color-subtle);
 }
@@ -295,6 +319,9 @@ pre {
 }
 
 .post-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   font-weight: 600;
   color: var(--color-accent);
 }
@@ -302,6 +329,15 @@ pre {
 .post-card__cta:hover,
 .post-card__cta:focus {
   text-decoration: underline;
+}
+
+.post-card__cta-icon {
+  transition: transform 150ms ease;
+}
+
+.post-card__cta:hover .post-card__cta-icon,
+.post-card__cta:focus .post-card__cta-icon {
+  transform: translateX(0.2rem);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- add inline SVG icons for authors, publish dates, and call-to-action links on the blog index
- introduce shared icon styling along with spacing adjustments for post metadata and CTA alignment

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0bcad7f9083328bea5b081f00d358