### PR TITLE
Revamp blog typography and navigation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,6 +88,168 @@ function buildAmazonLink(productId, textOverride) {
   return `<a ${attributes.join(" ")}>${escapeHtml(linkText)}</a>`;
 }
 
+function decodeHtmlEntities(value) {
+  if (value === undefined || value === null) return "";
+  return String(value)
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+}
+
+function normalizePlainText(value) {
+  return decodeHtmlEntities(value)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function slugifyHeading(value) {
+  return normalizePlainText(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function preparePostContent(content, pageTitle) {
+  if (!content) {
+    return { html: content, headings: [] };
+  }
+
+  let html = String(content);
+
+  const firstHeadingMatch = html.match(/^[\s\uFEFF\xA0]*<h1[^>]*>([\s\S]*?)<\/h1>[\s\uFEFF\xA0]*/i);
+
+  if (firstHeadingMatch) {
+    const [fullMatch, innerHtml] = firstHeadingMatch;
+    const normalizedHeading = normalizePlainText(innerHtml);
+    const normalizedTitle = normalizePlainText(pageTitle || "");
+
+    if (normalizedTitle && normalizedHeading && normalizedHeading === normalizedTitle) {
+      html = html.replace(fullMatch, "");
+    } else {
+      const leadingWhitespace = fullMatch.match(/^[\s\uFEFF\xA0]*/)[0];
+      const trailingWhitespace = fullMatch.match(/[\s\uFEFF\xA0]*$/)[0];
+      const headingMarkup = fullMatch.slice(
+        leadingWhitespace.length,
+        fullMatch.length - trailingWhitespace.length
+      );
+
+      const demotedHeading = headingMarkup
+        .replace(/<h1/gi, "<h2")
+        .replace(/<\/h1>/gi, "</h2>");
+
+      html = html.replace(
+        fullMatch,
+        `${leadingWhitespace}${demotedHeading}${trailingWhitespace}`
+      );
+    }
+  }
+
+  const headings = [];
+  const usedIds = new Set();
+
+  const headingPattern = /<h([23])([^>]*)>([\s\S]*?)<\/h\1>/gi;
+
+  html = html.replace(headingPattern, (match, level, rawAttrs, innerHtml) => {
+    const text = normalizePlainText(innerHtml);
+    if (!text) {
+      return match;
+    }
+
+    const existingIdMatch = rawAttrs && rawAttrs.match(/\sid\s*=\s*["']([^"']+)["']/i);
+    const existingId = existingIdMatch ? existingIdMatch[1] : "";
+    const slugBase = existingId || slugifyHeading(innerHtml);
+    const fallback = `section-${headings.length + 1}`;
+    const safeBase = slugBase || fallback;
+
+    let candidate = safeBase;
+    let suffix = 2;
+    while (usedIds.has(candidate)) {
+      candidate = `${safeBase}-${suffix++}`;
+    }
+    usedIds.add(candidate);
+
+    const withoutId = rawAttrs
+      ? rawAttrs.replace(/\sid\s*=\s*["'][^"']*["']/i, "").replace(/\s+/g, " ").trim()
+      : "";
+    const attributes = withoutId ? ` ${withoutId}` : "";
+    const headingMarkup = `<h${level}${attributes} id="${candidate}">${innerHtml}</h${level}>`;
+
+    headings.push({ level: Number(level), id: candidate, text });
+    return headingMarkup;
+  });
+
+  return { html, headings };
+}
+
+function buildAbsoluteUrl(path, site) {
+  if (!path) {
+    return site && site.url ? new URL(site.base || "", site.url).toString() : path;
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  if (!site || !site.url) {
+    return path;
+  }
+
+  const basePath = (site.base || "").replace(/\/$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const fullPath = normalizedPath.startsWith(basePath)
+    ? normalizedPath
+    : `${basePath}${normalizedPath}`;
+
+  return new URL(fullPath || "/", site.url).toString();
+}
+
+function normalizeBreadcrumbTrail(trail, site, canonicalUrl) {
+  const output = [];
+  const entries = Array.isArray(trail) ? trail : [];
+
+  entries.forEach((crumb, index) => {
+    if (!crumb) return;
+    const label = normalizePlainText(crumb.label || crumb.name || "");
+    if (!label) return;
+
+    let targetUrl = crumb.url || crumb.href || "";
+    if (!targetUrl && index === entries.length - 1) {
+      targetUrl = canonicalUrl;
+    }
+
+    const resolvedUrl = buildAbsoluteUrl(targetUrl || canonicalUrl, site);
+    if (!resolvedUrl) return;
+
+    output.push({ label, url: resolvedUrl });
+  });
+
+  if (canonicalUrl && !output.some((item) => item.url === canonicalUrl)) {
+    const fallbackLabel = output.length ? output[output.length - 1].label : "Current page";
+    output.push({ label: fallbackLabel, url: canonicalUrl });
+  }
+
+  return output;
+}
+
+function buildBreadcrumbLd(trail, site, canonicalUrl) {
+  const normalized = normalizeBreadcrumbTrail(trail, site, canonicalUrl);
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: normalized.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.label,
+      item: item.url,
+    })),
+  };
+}
+
 module.exports = function (eleventyConfig) {
   // Pretty date, e.g., "September 18, 2025"
   eleventyConfig.addFilter("date", (value, fmt = "MMMM d, yyyy") =>
@@ -105,63 +267,29 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("amazonLink", amazonLinkHelper);
   eleventyConfig.addShortcode("amazonLink", amazonLinkHelper);
 
-  eleventyConfig.addFilter("normalizePostHeadings", (content, pageTitle) => {
-    if (!content) return content;
+  eleventyConfig.addFilter("preparePostContent", (content, pageTitle) =>
+    preparePostContent(content, pageTitle)
+  );
 
-    const html = String(content);
-    const firstHeadingMatch = html.match(/^[\s\uFEFF\xA0]*<h1[^>]*>([\s\S]*?)<\/h1>[\s\uFEFF\xA0]*/i);
-
-    if (!firstHeadingMatch) {
-      return html;
-    }
-
-    const [fullMatch, innerHtml] = firstHeadingMatch;
-
-    const decodeHtmlEntities = (value) =>
-      value
-        .replace(/&amp;/gi, "&")
-        .replace(/&lt;/gi, "<")
-        .replace(/&gt;/gi, ">")
-        .replace(/&quot;/gi, '"')
-        .replace(/&#39;/gi, "'");
-
-    const normalizeText = (value) =>
-      decodeHtmlEntities(String(value || ""))
-        .replace(/<[^>]*>/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
-
-    const normalizedHeading = normalizeText(innerHtml);
-    const normalizedTitle = normalizeText(pageTitle);
-
-    if (normalizedTitle && normalizedHeading && normalizedHeading === normalizedTitle) {
-      return html.replace(fullMatch, "");
-    }
-
-    const leadingWhitespace = fullMatch.match(/^[\s\uFEFF\xA0]*/)[0];
-    const trailingWhitespace = fullMatch.match(/[\s\uFEFF\xA0]*$/)[0];
-    const headingMarkup = fullMatch.slice(
-      leadingWhitespace.length,
-      fullMatch.length - trailingWhitespace.length
-    );
-
-    const demotedHeading = headingMarkup
-      .replace(/<h1/gi, "<h2")
-      .replace(/<\/h1>/gi, "</h2>");
-
-    return html.replace(fullMatch, `${leadingWhitespace}${demotedHeading}${trailingWhitespace}`);
-  });
+  eleventyConfig.addFilter("normalizePostHeadings", (content, pageTitle) =>
+    preparePostContent(content, pageTitle).html
+  );
 
   // Build absolute URLs safely; ensure site.base (e.g., /blog) is present
   // Expects config.site like: { "url": "https://luggage-scale.com", "base": "/blog" }
-  eleventyConfig.addFilter("absoluteUrl", (path, site) => {
-    if (!site || !site.url) return path;
-    let p = path || "/";
-    if (!p.startsWith(site.base)) {
-      p = site.base.replace(/\/$/, "") + (p.startsWith("/") ? p : "/" + p);
-    }
-    return new URL(p, site.url).toString();
-  });
+  eleventyConfig.addFilter("absoluteUrl", (path, site) => buildAbsoluteUrl(path, site));
+
+  eleventyConfig.addFilter("jsonify", (value) =>
+    JSON.stringify(value, null, 2)
+  );
+
+  eleventyConfig.addFilter("breadcrumbJsonLd", (trail, site, canonicalUrl) =>
+    buildBreadcrumbLd(trail, site, canonicalUrl)
+  );
+
+  eleventyConfig.addFilter("resolveBreadcrumbTrail", (trail, site, canonicalUrl) =>
+    normalizeBreadcrumbTrail(trail, site, canonicalUrl)
+  );
 
   // Posts collection (newest first)
   eleventyConfig.addCollection("posts", (api) =>

--- a/blog-src/_includes/layouts/base.njk
+++ b/blog-src/_includes/layouts/base.njk
@@ -56,9 +56,27 @@
   <link rel="stylesheet" href="{{ config.site.base }}/static/style.css">
 </head>
 <body>
-  <header>
+  <header class="site-header">
     <div class="container">
-      <a href="{{ config.site.base }}/"><strong>{{ config.site.name }}</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="{{ config.site.base }}/"><strong>{{ config.site.name }}</strong></a>
+      </nav>
+      {% set breadcrumbTrail = breadcrumbs %}
+      {% if breadcrumbTrail %}
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          {% for crumb in breadcrumbTrail %}
+          <li class="breadcrumbs__item">
+            {% if loop.last %}
+            <span aria-current="page">{{ crumb.label }}</span>
+            {% else %}
+            <a href="{{ crumb.url }}">{{ crumb.label }}</a>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ol>
+      </nav>
+      {% endif %}
     </div>
   </header>
 

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -50,16 +50,95 @@
   {% set ogImageAlt = resolvedOgImageAlt %}
   {% include "head.njk" %}
   <link rel="stylesheet" href="{{ config.site.base }}/static/style.css">
+  {% set summary = excerpt or description or config.seo.defaultDescription %}
+  {% set canonicalHref = canonicalUrl or (page.url | absoluteUrl(site)) %}
+  {% set basePath = config.site.base or '' %}
+  {% if basePath | length %}
+    {% if basePath | last == '/' %}
+      {% set blogHomePath = basePath %}
+    {% else %}
+      {% set blogHomePath = basePath + '/' %}
+    {% endif %}
+  {% else %}
+    {% set blogHomePath = '/' %}
+  {% endif %}
+  {% set breadcrumbTrail = breadcrumbs or [
+    { "label": config.site.name, "url": blogHomePath },
+    { "label": title, "url": page.url }
+  ] %}
+  {% set prepared = content | preparePostContent(title) %}
+  {% set breadcrumbStructuredData = breadcrumbTrail | breadcrumbJsonLd(site, canonicalHref) %}
+  {% set publisherLogo = site.logoPath %}
+  {% if publisherLogo %}
+    {% set publisherLogo = publisherLogo | absoluteUrl(site) %}
+  {% endif %}
+  {% set articleImage = resolvedOgImage %}
+  {% if articleImage %}
+    {% set articleImage = articleImage | absoluteUrl(site) %}
+  {% endif %}
+  {% set publishedIso = resolvedPublished | isoDate %}
+  {% set modifiedIso = (resolvedModified or resolvedPublished) | isoDate %}
+  {% if publisherLogo %}
+    {% set publisherData = {
+      "@type": "Organization",
+      "name": site.name,
+      "logo": {
+        "@type": "ImageObject",
+        "url": publisherLogo
+      }
+    } %}
+  {% else %}
+    {% set publisherData = {
+      "@type": "Organization",
+      "name": site.name
+    } %}
+  {% endif %}
+  {% set articleStructuredData = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": title,
+    "description": summary,
+    "datePublished": publishedIso,
+    "dateModified": modifiedIso,
+    "mainEntityOfPage": canonicalHref,
+    "author": [{
+      "@type": "Organization",
+      "name": resolvedMetaAuthor
+    }],
+    "publisher": publisherData,
+    "image": articleImage
+  } %}
+  <script type="application/ld+json">{{ articleStructuredData | jsonify | safe }}</script>
+  {% if breadcrumbStructuredData.itemListElement and breadcrumbStructuredData.itemListElement | length %}
+  <script type="application/ld+json">{{ breadcrumbStructuredData | jsonify | safe }}</script>
+  {% endif %}
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="{{ config.site.base }}/"><strong>{{ config.site.name }}</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="{{ config.site.base }}/"><strong>{{ config.site.name }}</strong></a>
+      </nav>
+      {% if breadcrumbTrail %}
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          {% for crumb in breadcrumbTrail %}
+          <li class="breadcrumbs__item">
+            {% if loop.last %}
+            <span aria-current="page">{{ crumb.label }}</span>
+            {% else %}
+            <a href="{{ crumb.url }}">{{ crumb.label }}</a>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ol>
+      </nav>
+      {% endif %}
     </div>
   </header>
 
   <main class="container">
-    <article class="post" data-canonical="{{ canonicalUrl }}">
+    <article class="post" data-canonical="{{ canonicalHref }}">
       <header class="post__header">
         {% if title %}
         <h1 class="post__title">{{ title }}</h1>
@@ -73,21 +152,43 @@
           <time class="post-meta__date" datetime="{{ date | isoDate }}">{{ date | date("MMMM d, yyyy") }}</time>
           {% endif %}
         </div>
-        {% set summary = excerpt or description or config.seo.defaultDescription %}
         {% if summary %}
         <p class="post__excerpt">{{ summary }}</p>
         {% endif %}
       </header>
 
-      <div class="post__body">
-        {{ content | normalizePostHeadings(title) | safe }}
-      </div>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            {{ prepared.html | safe }}
+          </div>
 
-      {% if affiliateDisclaimer %}
-      <aside class="post__disclaimer">
-        {{ affiliateDisclaimer }}
-      </aside>
-      {% endif %}
+          {% if affiliateDisclaimer %}
+          <aside class="post__disclaimer">
+            {{ affiliateDisclaimer }}
+          </aside>
+          {% endif %}
+        </div>
+
+        {% if prepared.headings and prepared.headings | length %}
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                {% for heading in prepared.headings %}
+                {% if heading.level <= 3 %}
+                <li class="post__toc-item post__toc-item--level-{{ heading.level }}">
+                  <a class="post__toc-link" href="#{{ heading.id }}">{{ heading.text }}</a>
+                </li>
+                {% endif %}
+                {% endfor %}
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        {% endif %}
+      </div>
     </article>
   </main>
 

--- a/blog-src/index.njk
+++ b/blog-src/index.njk
@@ -2,6 +2,9 @@
 layout: layouts/base.njk
 title: "Blog"
 description: "Latest articles, guides, and tips from the uPatch luggage scale team."
+breadcrumbs:
+  - label: "Blog"
+    url: "/blog/"
 pagination:
   data: collections.posts
   size: 10

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -1,20 +1,30 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap");
+
 /* Blog design tokens */
 :root {
-  color-scheme: light dark;
-  --font-sans: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  color-scheme: dark;
+  --font-sans: "Plus Jakarta Sans", "InterVariable", "Inter var", "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --color-bg: #f8fafc;
-  --color-surface: #ffffff;
-  --color-text: #0f172a;
-  --color-muted: #64748b;
-  --color-subtle: #94a3b8;
-  --color-border: #e2e8f0;
-  --color-accent: #2563eb;
-  --shadow-xs: 0 4px 12px rgba(15, 23, 42, 0.04);
-  --shadow-sm: 0 18px 45px rgba(15, 23, 42, 0.08);
-  --radius-sm: 0.5rem;
-  --radius-md: 0.75rem;
-  --max-reading-width: 68ch;
+  --color-bg: #071427;
+  --color-surface: #122746;
+  --color-surface-soft: #18335c;
+  --color-surface-elevated: rgba(21, 44, 78, 0.82);
+  --color-text: #f3f8ff;
+  --color-muted: #c9d7f2;
+  --color-subtle: #8aa3c3;
+  --color-border: rgba(112, 158, 214, 0.28);
+  --color-border-strong: rgba(112, 158, 214, 0.45);
+  --color-accent: #4db8ff;
+  --color-accent-secondary: #53dcc6;
+  --color-accent-soft: rgba(83, 220, 198, 0.2);
+  --shadow-xs: 0 10px 24px rgba(3, 12, 26, 0.35);
+  --shadow-sm: 0 32px 70px rgba(5, 18, 37, 0.55);
+  --radius-sm: 0.65rem;
+  --radius-md: 0.95rem;
+  --max-reading-width: 72ch;
+  --toc-width: 19rem;
+  --gradient-divider: linear-gradient(90deg, rgba(83, 220, 198, 0.4) 0%, rgba(77, 184, 255, 0.35) 100%);
+  --gradient-quote: linear-gradient(135deg, rgba(83, 220, 198, 0.22), rgba(77, 184, 255, 0.16));
   --space-0: 0;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -24,6 +34,7 @@
   --space-6: 2rem;
   --space-7: 3rem;
   --space-8: 4rem;
+  --space-9: 5rem;
 }
 
 /* Base layout */
@@ -31,21 +42,28 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: var(--font-sans);
-  font-size: 1rem;
-  line-height: 1.65;
+  font-size: clamp(1.05rem, 1rem + 0.25vw, 1.1rem);
+  line-height: 1.7;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(24, 52, 96, 0.45), transparent 55%), var(--color-bg);
   background-color: var(--color-bg);
   color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga" 1, "kern" 1;
 }
 
 a {
-  color: var(--color-accent);
+  color: var(--color-accent-secondary);
   text-decoration: none;
+  font-weight: 500;
   transition: color 150ms ease, text-decoration-color 150ms ease;
 }
 
 a:hover,
 a:focus {
+  color: var(--color-accent);
   text-decoration: underline;
+  text-decoration-color: currentColor;
 }
 
 img {
@@ -55,50 +73,134 @@ img {
   border-radius: var(--radius-sm);
 }
 
+.icon {
+  width: 1.1em;
+  height: 1.1em;
+  display: inline-block;
+  flex-shrink: 0;
+  color: var(--color-accent-secondary);
+  vertical-align: middle;
+}
+
 .container {
-  width: min(100% - 2.5rem, 62rem);
+  width: min(100%, 78rem);
   margin: 0 auto;
+  padding-left: clamp(1.5rem, 4vw, 3.5rem);
+  padding-right: clamp(1.5rem, 4vw, 3.5rem);
 }
 
-header,
+.site-header {
+  background: rgba(18, 39, 70, 0.92);
+  backdrop-filter: blur(18px);
+  padding: var(--space-5) 0 var(--space-4);
+  border-bottom: 1px solid rgba(112, 158, 214, 0.25);
+  margin-bottom: var(--space-7);
+  box-shadow: var(--shadow-xs);
+  position: relative;
+  z-index: 1;
+}
+
 footer {
-  background: transparent;
-  color: var(--color-text);
-}
-
-header {
-  padding: var(--space-4) 0;
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--space-6);
-}
-
-footer {
-  padding: var(--space-5) 0;
-  border-top: 1px solid var(--color-border);
+  background: rgba(18, 39, 70, 0.9);
+  padding: var(--space-6) 0;
+  border-top: 1px solid rgba(112, 158, 214, 0.2);
   margin-top: var(--space-8);
   font-size: 0.95rem;
-  color: var(--color-muted);
+  color: var(--color-subtle);
+  box-shadow: var(--shadow-xs);
 }
 
 main {
-  padding: var(--space-6) 0;
+  padding: var(--space-7) 0 var(--space-8);
 }
 
-@media (max-width: 640px) {
+.site-header__nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.site-header__brand:hover,
+.site-header__brand:focus {
+  color: var(--color-accent);
+}
+
+.breadcrumbs {
+  margin-top: var(--space-3);
+  font-size: 0.95rem;
+  color: var(--color-subtle);
+}
+
+.breadcrumbs__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.breadcrumbs__item:not(:last-child)::after {
+  content: "›";
+  opacity: 0.5;
+  color: var(--color-subtle);
+  font-size: 1rem;
+}
+
+.breadcrumbs__item a {
+  color: var(--color-accent-secondary);
+  font-weight: 500;
+}
+
+.breadcrumbs__item span[aria-current="page"] {
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
   .container {
-    width: min(100% - 1.5rem, 60rem);
+    padding-left: clamp(1.25rem, 6vw, 2rem);
+    padding-right: clamp(1.25rem, 6vw, 2rem);
   }
 
-  header {
-    margin-bottom: var(--space-5);
-  }
-
-  footer {
-    margin-top: var(--space-7);
+  .site-header {
+    margin-bottom: var(--space-6);
   }
 
   main {
-    padding: var(--space-5) 0;
+    padding: var(--space-6) 0 var(--space-7);
+  }
+}
+
+@media (max-width: 520px) {
+  .breadcrumbs {
+    font-size: 0.9rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .container {
+    width: min(100%, 84rem);
+    padding-left: clamp(2.5rem, 6vw, 4.5rem);
+    padding-right: clamp(2.5rem, 6vw, 4.5rem);
   }
 }
 
@@ -108,72 +210,115 @@ h2,
 h3,
 h4 {
   margin: 0 0 var(--space-3);
-  font-weight: 600;
-  line-height: 1.15;
+  line-height: 1.2;
   color: var(--color-text);
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 h1,
 .heading-xl {
-  font-size: clamp(2.25rem, 5vw, 3rem);
+  font-size: clamp(2.5rem, 5vw, 3.35rem);
+  font-weight: 750;
 }
 
 h2,
 .heading-lg {
-  font-size: clamp(1.85rem, 3.5vw, 2.35rem);
+  font-size: clamp(1.95rem, 3.5vw, 2.5rem);
+  font-weight: 650;
 }
 
 h3,
 .heading-md {
-  font-size: clamp(1.45rem, 2.5vw, 1.9rem);
+  font-size: clamp(1.45rem, 2.8vw, 1.95rem);
+  font-weight: 600;
+  color: var(--color-muted);
 }
 
 h4,
 .heading-sm {
   font-size: 1.2rem;
+  font-weight: 600;
 }
 
 p {
   margin: 0 0 var(--space-4);
 }
 
-ul,
-ol {
-  margin: 0 0 var(--space-4);
-  padding-left: 1.35rem;
-}
-
-hr {
-  border: none;
-  border-top: 1px solid var(--color-border);
-  margin: var(--space-6) 0;
-}
-
-blockquote {
-  margin: var(--space-6) 0;
-  padding: var(--space-3) var(--space-4);
-  border-left: 3px solid var(--color-accent);
-  background-color: rgba(37, 99, 235, 0.08);
-  color: var(--color-text);
-  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  font-style: italic;
+strong {
+  font-weight: 650;
 }
 
 code,
 pre {
   font-family: var(--font-mono);
-  background-color: rgba(15, 23, 42, 0.05);
+  background-color: rgba(12, 30, 54, 0.65);
+  color: var(--color-text);
 }
 
 code {
-  padding: 0.15em 0.35em;
-  border-radius: 0.35rem;
+  padding: 0.15em 0.45em;
+  border-radius: 0.45rem;
+  border: 1px solid var(--color-border);
 }
 
 pre {
   overflow-x: auto;
   padding: var(--space-3);
   border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+hr {
+  border: none;
+  height: 1px;
+  background: var(--gradient-divider);
+  border-radius: 999px;
+  margin: var(--space-7) 0;
+  position: relative;
+  overflow: visible;
+}
+
+hr::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: -0.5rem;
+  width: 5rem;
+  height: 1rem;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22120%22%20height%3D%2210%22%20fill%3D%22none%22%20viewBox%3D%220%200%20120%2010%22%3E%3Cpath%20d%3D%22M0%206C15%202%2030%202%2045%206C60%209%2075%209%2090%206C105%203%20110%202%20120%205%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.45%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+  opacity: 0.7;
+}
+
+blockquote {
+  margin: var(--space-7) 0;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-strong);
+  background: var(--gradient-quote);
+  color: var(--color-text);
+  position: relative;
+  overflow: hidden;
+}
+
+blockquote::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
 }
 
 /* Utility spacing helpers */
@@ -206,7 +351,7 @@ pre {
 .blog-index__intro {
   margin: 0 0 var(--space-6);
   max-width: 60ch;
-  color: var(--color-muted);
+  color: var(--color-subtle);
 }
 
 .post-grid {
@@ -229,14 +374,23 @@ pre {
 }
 
 .post-card {
-  background-color: var(--color-surface);
+  background: linear-gradient(135deg, rgba(26, 53, 95, 0.9), rgba(18, 39, 70, 0.95));
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-5), 2vw + 1rem, var(--space-6));
+  padding: clamp(var(--space-5), 2vw + 1.25rem, var(--space-6));
   display: grid;
   gap: var(--space-5);
   height: 100%;
+  color: var(--color-text);
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.post-card:hover,
+.post-card:focus-within {
+  transform: translateY(-2px);
+  border-color: rgba(83, 220, 198, 0.45);
+  box-shadow: 0 36px 70px rgba(5, 18, 37, 0.6);
 }
 
 .post-card--with-image {
@@ -248,7 +402,7 @@ pre {
   border-radius: calc(var(--radius-md) - var(--space-1));
   overflow: hidden;
   aspect-ratio: 16 / 9;
-  background-color: rgba(148, 163, 184, 0.2);
+  background-color: rgba(77, 184, 255, 0.12);
 }
 
 .post-card__media img {
@@ -264,8 +418,9 @@ pre {
 
 .post-card__title {
   margin: 0;
-  font-size: clamp(1.65rem, 2.4vw, 2.05rem);
+  font-size: clamp(1.65rem, 2.4vw, 2.1rem);
   line-height: 1.25;
+  font-weight: 700;
 }
 
 .post-card__title a {
@@ -277,10 +432,17 @@ pre {
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2);
-  font-size: 0.9rem;
-  letter-spacing: 0.04em;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: var(--color-subtle);
+}
+
+.post-meta__author,
+.post-meta__date {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 .post-meta__separator {
@@ -289,10 +451,13 @@ pre {
 
 .post-card__excerpt {
   margin: 0;
-  color: var(--color-text);
+  color: var(--color-muted);
 }
 
 .post-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   font-weight: 600;
   color: var(--color-accent);
 }
@@ -300,6 +465,15 @@ pre {
 .post-card__cta:hover,
 .post-card__cta:focus {
   text-decoration: underline;
+}
+
+.post-card__cta-icon {
+  transition: transform 150ms ease;
+}
+
+.post-card__cta:hover .post-card__cta-icon,
+.post-card__cta:focus .post-card__cta-icon {
+  transform: translateX(0.2rem);
 }
 
 @media (min-width: 768px) {
@@ -324,10 +498,11 @@ pre {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-muted);
 }
 
 .pagination__link {
-  color: var(--color-accent);
+  color: var(--color-accent-secondary);
   font-weight: 600;
 }
 
@@ -341,22 +516,45 @@ pre {
 
 /* Post layout */
 .post {
-  background-color: var(--color-surface);
+  background: linear-gradient(135deg, rgba(20, 45, 80, 0.95), rgba(15, 34, 64, 0.92));
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-6), 4vw + 1rem, var(--space-8));
+  padding: clamp(var(--space-6), 4vw + 1.25rem, var(--space-9));
   display: grid;
   gap: var(--space-6);
+  color: var(--color-text);
+  position: relative;
+  overflow: hidden;
 }
 
 .post__header {
   display: grid;
   gap: var(--space-4);
+  position: relative;
+  padding-bottom: var(--space-2);
+}
+
+.post__header::before {
+  content: "";
+  position: absolute;
+  inset: -30% -10% auto -10%;
+  height: 140%;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22220%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20220%22%3E%3Cpath%20d%3D%22M-20%20160C80%20120%20160%20200%20260%20160C340%20130%20380%20150%20460%20120%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.25%22/%3E%3Cpath%20d%3D%22M-10%20120C90%2080%20180%20140%20280%20110C360%2090%20420%20110%20500%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: cover;
+  opacity: 0.25;
+  pointer-events: none;
+}
+
+.post__header > * {
+  position: relative;
 }
 
 .post__title {
   margin: 0;
+  font-weight: 760;
+  line-height: 1.2;
 }
 
 .post__excerpt {
@@ -365,40 +563,349 @@ pre {
   font-size: 1.1rem;
 }
 
+.post__content-grid {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.post__content-column {
+  display: grid;
+  gap: var(--space-6);
+  align-content: start;
+}
+
 .post__body {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-5);
   font-size: 1.05rem;
-  line-height: 1.75;
+  line-height: 1.7;
   max-width: var(--max-reading-width);
   width: 100%;
   margin: 0 auto;
+  color: var(--color-text);
 }
 
 .post__body > * {
   margin: 0;
 }
 
-.post__disclaimer {
-  margin: 0 auto;
-  padding: var(--space-4);
+.post__body h2 {
+  margin-top: var(--space-7);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid rgba(83, 220, 198, 0.18);
+  position: relative;
+}
+
+.post__body h2::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  width: 3.5rem;
+  height: 3px;
+  background: var(--gradient-divider);
+  border-radius: 999px;
+}
+
+.post__body h2:first-of-type {
+  margin-top: var(--space-4);
+}
+
+.post__body h3 {
+  margin-top: var(--space-5);
+  padding-left: var(--space-3);
+  color: var(--color-subtle);
+  position: relative;
+  font-weight: 600;
+}
+
+.post__body h3::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.65rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.8), rgba(83, 220, 198, 0.6));
+  box-shadow: 0 0 0 4px rgba(77, 184, 255, 0.12);
+}
+
+.post__body h2,
+.post__body h3 {
+  scroll-margin-top: clamp(6rem, 7vw, 8rem);
+}
+
+.post__body a {
+  color: var(--color-accent-secondary);
+  text-decoration: underline;
+  text-decoration-color: rgba(83, 220, 198, 0.45);
+  font-weight: 500;
+}
+
+.post__body a:hover,
+.post__body a:focus {
+  color: var(--color-accent);
+  text-decoration-color: rgba(77, 184, 255, 0.55);
+}
+
+.post__body ul,
+.post__body ol {
+  list-style: none;
+  margin: 0 0 var(--space-5);
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.post__body li {
+  position: relative;
+  padding: calc(var(--space-3) + 0.15rem) var(--space-4) calc(var(--space-3) + 0.15rem) calc(var(--space-4) + 2.1rem);
+  background: rgba(15, 32, 58, 0.35);
+  border: 1px solid rgba(112, 158, 214, 0.24);
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  background-color: rgba(37, 99, 235, 0.08);
+  line-height: 1.65;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.post__body li:hover {
+  border-color: rgba(83, 220, 198, 0.35);
+  transform: translateY(-1px);
+}
+
+.post__body li strong {
   color: var(--color-text);
+}
+
+.post__body li p:last-child {
+  margin-bottom: 0;
+}
+
+.post__body ul li::before {
+  content: "";
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(83, 220, 198, 0.25), transparent 70%),
+    url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%2214%22%20height%3D%2212%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2012%22%3E%3Cpath%20d%3D%22M1.5%206.5L4.8%209.5L12.5%201.5%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E") center/0.85rem 0.85rem no-repeat;
+}
+
+.post__body ol {
+  counter-reset: step;
+}
+
+.post__body ol li {
+  counter-increment: step;
+}
+
+.post__body ol li::before {
+  content: counter(step);
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.45), rgba(83, 220, 198, 0.45));
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 12px rgba(5, 18, 37, 0.3);
+  font-variant-numeric: tabular-nums;
+}
+
+.post__body hr {
+  margin: var(--space-7) auto;
+}
+
+.post__body blockquote {
+  margin: var(--space-7) 0;
+}
+
+.post__disclaimer {
+  margin: var(--space-7) auto 0;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(83, 220, 198, 0.28);
+  background: var(--color-surface-elevated);
+  color: var(--color-muted);
   font-size: 0.95rem;
   max-width: var(--max-reading-width);
   width: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.post__disclaimer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22160%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20160%22%3E%3Cpath%20d%3D%22M-40%20120C40%2090%20140%20140%20220%20110C300%2080%20340%20100%20440%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.2%22/%3E%3Cpath%20d%3D%22M-10%2090C70%2060%20140%2090%20240%2070C320%2060%20390%2080%20480%2060%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.4%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: cover;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.post__disclaimer > * {
+  position: relative;
+  margin: 0;
+}
+
+.post__toc {
+  display: none;
+}
+
+.post__toc-inner {
+  position: sticky;
+  top: clamp(5.5rem, 8vw, 7rem);
+  background: rgba(18, 39, 70, 0.85);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-xs);
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.post__toc-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-subtle);
+}
+
+.post__toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.post__toc-item--level-3 {
+  padding-left: var(--space-2);
+}
+
+.post__toc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-muted);
+  padding: 0.35rem 0;
+  border-left: 2px solid transparent;
+  transition: color 150ms ease, border-color 150ms ease;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.post__toc-link::before {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.9), rgba(83, 220, 198, 0.7));
+  opacity: 0.6;
+}
+
+.post__toc-item--level-3 .post__toc-link {
+  font-size: 0.9rem;
+  color: rgba(201, 215, 242, 0.8);
+}
+
+.post__toc-item--level-3 .post__toc-link::before {
+  width: 0.35rem;
+  height: 0.35rem;
+  opacity: 0.5;
+}
+
+.post__toc-link:hover,
+.post__toc-link:focus {
+  color: var(--color-accent);
+  border-color: rgba(77, 184, 255, 0.45);
+}
+
+.post__toc-link:focus-visible {
+  outline: 2px solid rgba(83, 220, 198, 0.5);
+  outline-offset: 2px;
+}
+
+@media (min-width: 960px) {
+  .post__content-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, var(--toc-width));
+    align-items: start;
+    gap: var(--space-7);
+  }
+
+  .post__toc {
+    display: block;
+  }
+}
+
+@media (min-width: 900px) {
+  .post__body ol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-4);
+  }
+}
+
+@media (max-width: 960px) {
+  .post__content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .post__body ul,
+  .post__body ol {
+    gap: var(--space-2);
+  }
 }
 
 @media (max-width: 600px) {
   .post {
-    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-6));
+    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-7));
+  }
+
+  .post__body li {
+    padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 1.8rem);
+  }
+
+  .post__body ul li::before,
+  .post__body ol li::before {
+    left: var(--space-3);
   }
 }
 
-/* Empty state */
-.blog-list__empty {
-  font-style: italic;
-  color: var(--color-muted);
+/* Footer */
+footer .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+footer a {
+  color: var(--color-accent-secondary);
+}
+
+@media (max-width: 640px) {
+  footer .container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
 }

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Avoid Overweight Baggage Fees with a Luggage Scale",
+  "description": "Step-by-step plan to weigh your suitcases ahead of travel so you skip surprise overweight fees.",
+  "datePublished": "2025-09-11",
+  "dateModified": "2025-09-11",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Avoid Overweight Baggage Fees with a Luggage Scale",
+      "item": "https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Avoid Overweight Baggage Fees with a Luggage Scale</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Step-by-step plan to weigh your suitcases ahead of travel so you skip surprise overweight fees.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Business Travel: Weekly Packing System to Eliminate Overages",
+  "description": "Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.",
+  "datePublished": "2025-09-19",
+  "dateModified": "2025-09-19",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Business Travel: Weekly Packing System to Eliminate Overages",
+      "item": "https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Business Travel: Weekly Packing System to Eliminate Overages</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Calibrate & Verify: Trusting Your Luggage Scale’s Readout",
+  "description": "Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.",
+  "datePublished": "2025-09-18",
+  "dateModified": "2025-09-18",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Calibrate & Verify: Trusting Your Luggage Scale’s Readout",
+      "item": "https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Carry‑On Weight Limits: What to Know (Always Check Your Airline)",
+  "description": "Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.",
+  "datePublished": "2025-09-13",
+  "dateModified": "2025-09-13",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Carry‑On Weight Limits: What to Know (Always Check Your Airline)",
+      "item": "https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Carry‑On Weight Limits: What to Know (Always Check Your Airline)</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Family Travel Checklist: Weigh Every Bag in 2 Minutes",
+  "description": "Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.",
+  "datePublished": "2025-09-16",
+  "dateModified": "2025-09-16",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Family Travel Checklist: Weigh Every Bag in 2 Minutes",
+      "item": "https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Family Travel Checklist: Weigh Every Bag in 2 Minutes</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Hello World — First Blog Post",
+  "description": "A quick welcome post introducing the uPatch luggage scale blog and what we'll be sharing.",
+  "datePublished": "2025-09-18",
+  "dateModified": "2025-09-18",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/hello-world/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Hello World — First Blog Post",
+      "item": "https://luggage-scale.com/blog/hello-world/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Hello World — First Blog Post</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,31 +224,53 @@
           
         </div>
         
-        
         <p class="post__excerpt">A quick welcome post introducing the uPatch luggage scale blog and what we&#39;ll be sharing.</p>
         
       </header>
 
-      <div class="post__body">
-        <p>This is your <strong>first test post</strong> in the new blog system.</p>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p>This is your <strong>first test post</strong> in the new blog system.</p>
 <ul>
 <li>Written in Markdown</li>
 <li>Stored in <code>/blog-src/posts/hello-world/index.md</code></li>
 <li>When built, it will publish to <code>/blog/hello-world/</code></li>
 </ul>
-<h2>Affiliate picks</h2>
+<h2 id="affiliate-picks">Affiliate picks</h2>
 <p>Want to try the gear we mention? Start with our go-to travel scale:</p>
 <p><a href="https://www.amazon.com/dp/B0AUPATCH01?tag=luggagescale-20" rel="sponsored noopener noreferrer" target="_blank" data-affiliate="amazon" data-asin="B0AUPATCH01" title="uPatch Digital Hanging Luggage Scale">Shop the uPatch luggage scale on Amazon</a></p>
 <p>Need help staying organized? &lt;a href=&quot;https://www.amazon.com/dp/B0BCUBESET1?tag=luggagescale-20&quot; rel=&quot;sponsored noopener noreferrer&quot; target=&quot;_blank&quot; data-affiliate=&quot;amazon&quot; data-asin=&quot;B0BCUBESET1&quot; title=&quot;Compression Packing Cubes Set&quot;&gt;Compression packing cubes on Amazon&lt;/a&gt;</p>
 <p><small>As an Amazon Associate we earn from qualifying purchases.</small></p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#affiliate-picks">Affiliate picks</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale",
+  "description": "Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.",
+  "datePublished": "2025-09-12",
+  "dateModified": "2025-09-12",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale",
+      "item": "https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -109,9 +109,25 @@
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>
-  <header>
+  <header class="site-header">
     <div class="container">
-      <a href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Blog</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -138,38 +154,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-20">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 20, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-20">September 20, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.</p>
           
-          <a class="post-card__cta" href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -188,38 +186,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-19">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 19, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-19">September 19, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.</p>
           
-          <a class="post-card__cta" href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -238,38 +218,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-18">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 18, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.</p>
           
-          <a class="post-card__cta" href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -288,38 +250,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-18">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 18, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-18">September 18, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">A quick welcome post introducing the uPatch luggage scale blog and what we&#39;ll be sharing.</p>
           
-          <a class="post-card__cta" href="/blog/hello-world/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/hello-world/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -338,38 +282,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-17">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 17, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-17">September 17, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.</p>
           
-          <a class="post-card__cta" href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -388,38 +314,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-16">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 16, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-16">September 16, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.</p>
           
-          <a class="post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -438,38 +346,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-15">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 15, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-15">September 15, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
           
-          <a class="post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -488,38 +378,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-14">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 14, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-14">September 14, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.</p>
           
-          <a class="post-card__cta" href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -538,38 +410,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-13">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 13, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-13">September 13, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.</p>
           
-          <a class="post-card__cta" href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Read the article →</a>
         </div>
       </article>
     </li>
@@ -588,38 +442,20 @@
           
           <p class="post-meta">
             
-            <span class="post-meta__author">
-              <svg class="icon post-meta__icon icon--author" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <circle cx="12" cy="8.5" r="3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></circle>
-                <path d="M5 19.5c0-3.04 3.13-5.5 7-5.5s7 2.46 7 5.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              uPatch Travel Team
-            </span>
+            <span class="post-meta__author">uPatch Travel Team</span>
             
             
             <span class="post-meta__separator" aria-hidden="true">•</span>
             
             
-            <time class="post-meta__date" datetime="2025-09-12">
-              <svg class="icon post-meta__icon icon--calendar" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-                <rect x="3" y="5" width="18" height="16" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></rect>
-                <path d="M16 3v4M8 3v4M3 11h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              </svg>
-              September 12, 2025
-            </time>
+            <time class="post-meta__date" datetime="2025-09-12">September 12, 2025</time>
             
           </p>
           
           
           <p class="post-card__excerpt">Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.</p>
           
-          <a class="post-card__cta" href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
-            Read the article
-            <svg class="icon post-card__cta-icon icon--arrow" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-              <path d="M5 12h12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
+          <a class="post-card__cta" href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">Read the article →</a>
         </div>
       </article>
     </li>

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "International vs. Domestic Trips: Planning for Weight Differences",
+  "description": "Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.",
+  "datePublished": "2025-09-17",
+  "dateModified": "2025-09-17",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "International vs. Domestic Trips: Planning for Weight Differences",
+      "item": "https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">International vs. Domestic Trips: Planning for Weight Differences</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb",
+  "description": "Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.",
+  "datePublished": "2025-09-14",
+  "dateModified": "2025-09-14",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb",
+      "item": "https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -109,9 +109,25 @@
   <link rel="stylesheet" href="/blog/static/style.css">
 </head>
 <body>
-  <header>
+  <header class="site-header">
     <div class="container">
-      <a href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Blog</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1,20 +1,30 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap");
+
 /* Blog design tokens */
 :root {
   color-scheme: dark;
-  --font-sans: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-sans: "Plus Jakarta Sans", "InterVariable", "Inter var", "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --color-bg: #0a1a2f;
-  --color-surface: #11294d;
-  --color-text: #f0f8ff;
-  --color-muted: #c5d6eb;
-  --color-subtle: #8fb0d3;
-  --color-border: #1c365b;
+  --color-bg: #071427;
+  --color-surface: #122746;
+  --color-surface-soft: #18335c;
+  --color-surface-elevated: rgba(21, 44, 78, 0.82);
+  --color-text: #f3f8ff;
+  --color-muted: #c9d7f2;
+  --color-subtle: #8aa3c3;
+  --color-border: rgba(112, 158, 214, 0.28);
+  --color-border-strong: rgba(112, 158, 214, 0.45);
   --color-accent: #4db8ff;
-  --shadow-xs: 0 6px 18px rgba(3, 12, 26, 0.3);
-  --shadow-sm: 0 26px 60px rgba(3, 12, 26, 0.45);
-  --radius-sm: 0.5rem;
-  --radius-md: 0.75rem;
-  --max-reading-width: 68ch;
+  --color-accent-secondary: #53dcc6;
+  --color-accent-soft: rgba(83, 220, 198, 0.2);
+  --shadow-xs: 0 10px 24px rgba(3, 12, 26, 0.35);
+  --shadow-sm: 0 32px 70px rgba(5, 18, 37, 0.55);
+  --radius-sm: 0.65rem;
+  --radius-md: 0.95rem;
+  --max-reading-width: 72ch;
+  --toc-width: 19rem;
+  --gradient-divider: linear-gradient(90deg, rgba(83, 220, 198, 0.4) 0%, rgba(77, 184, 255, 0.35) 100%);
+  --gradient-quote: linear-gradient(135deg, rgba(83, 220, 198, 0.22), rgba(77, 184, 255, 0.16));
   --space-0: 0;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -24,6 +34,7 @@
   --space-6: 2rem;
   --space-7: 3rem;
   --space-8: 4rem;
+  --space-9: 5rem;
 }
 
 /* Base layout */
@@ -31,38 +42,28 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: var(--font-sans);
-  font-size: 1rem;
-  line-height: 1.65;
+  font-size: clamp(1.05rem, 1rem + 0.25vw, 1.1rem);
+  line-height: 1.7;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(24, 52, 96, 0.45), transparent 55%), var(--color-bg);
   background-color: var(--color-bg);
   color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga" 1, "kern" 1;
 }
 
 a {
-  color: var(--color-accent);
+  color: var(--color-accent-secondary);
   text-decoration: none;
+  font-weight: 500;
   transition: color 150ms ease, text-decoration-color 150ms ease;
 }
 
 a:hover,
 a:focus {
-  text-decoration: underline;
-}
-
-.icon {
-  width: 1.1em;
-  height: 1.1em;
-  display: inline-block;
-  flex-shrink: 0;
   color: var(--color-accent);
-  vertical-align: middle;
-}
-
-.icon path,
-.icon rect,
-.icon circle,
-.icon line,
-.icon polyline {
-  vector-effect: non-scaling-stroke;
+  text-decoration: underline;
+  text-decoration-color: currentColor;
 }
 
 img {
@@ -72,48 +73,134 @@ img {
   border-radius: var(--radius-sm);
 }
 
-.container {
-  width: min(100% - 2.5rem, 62rem);
-  margin: 0 auto;
+.icon {
+  width: 1.1em;
+  height: 1.1em;
+  display: inline-block;
+  flex-shrink: 0;
+  color: var(--color-accent-secondary);
+  vertical-align: middle;
 }
 
-header {
-  background-color: var(--color-surface);
-  padding: var(--space-4) 0;
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--space-6);
+.container {
+  width: min(100%, 78rem);
+  margin: 0 auto;
+  padding-left: clamp(1.5rem, 4vw, 3.5rem);
+  padding-right: clamp(1.5rem, 4vw, 3.5rem);
+}
+
+.site-header {
+  background: rgba(18, 39, 70, 0.92);
+  backdrop-filter: blur(18px);
+  padding: var(--space-5) 0 var(--space-4);
+  border-bottom: 1px solid rgba(112, 158, 214, 0.25);
+  margin-bottom: var(--space-7);
   box-shadow: var(--shadow-xs);
+  position: relative;
+  z-index: 1;
 }
 
 footer {
-  background-color: var(--color-surface);
-  padding: var(--space-5) 0;
-  border-top: 1px solid var(--color-border);
+  background: rgba(18, 39, 70, 0.9);
+  padding: var(--space-6) 0;
+  border-top: 1px solid rgba(112, 158, 214, 0.2);
   margin-top: var(--space-8);
   font-size: 0.95rem;
-  color: var(--color-muted);
+  color: var(--color-subtle);
   box-shadow: var(--shadow-xs);
 }
 
 main {
-  padding: var(--space-6) 0;
+  padding: var(--space-7) 0 var(--space-8);
 }
 
-@media (max-width: 640px) {
+.site-header__nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.site-header__brand:hover,
+.site-header__brand:focus {
+  color: var(--color-accent);
+}
+
+.breadcrumbs {
+  margin-top: var(--space-3);
+  font-size: 0.95rem;
+  color: var(--color-subtle);
+}
+
+.breadcrumbs__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.breadcrumbs__item:not(:last-child)::after {
+  content: "›";
+  opacity: 0.5;
+  color: var(--color-subtle);
+  font-size: 1rem;
+}
+
+.breadcrumbs__item a {
+  color: var(--color-accent-secondary);
+  font-weight: 500;
+}
+
+.breadcrumbs__item span[aria-current="page"] {
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
   .container {
-    width: min(100% - 1.5rem, 60rem);
+    padding-left: clamp(1.25rem, 6vw, 2rem);
+    padding-right: clamp(1.25rem, 6vw, 2rem);
   }
 
-  header {
-    margin-bottom: var(--space-5);
-  }
-
-  footer {
-    margin-top: var(--space-7);
+  .site-header {
+    margin-bottom: var(--space-6);
   }
 
   main {
-    padding: var(--space-5) 0;
+    padding: var(--space-6) 0 var(--space-7);
+  }
+}
+
+@media (max-width: 520px) {
+  .breadcrumbs {
+    font-size: 0.9rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .container {
+    width: min(100%, 84rem);
+    padding-left: clamp(2.5rem, 6vw, 4.5rem);
+    padding-right: clamp(2.5rem, 6vw, 4.5rem);
   }
 }
 
@@ -123,67 +210,55 @@ h2,
 h3,
 h4 {
   margin: 0 0 var(--space-3);
-  font-weight: 600;
-  line-height: 1.15;
+  line-height: 1.2;
   color: var(--color-text);
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 h1,
 .heading-xl {
-  font-size: clamp(2.25rem, 5vw, 3rem);
+  font-size: clamp(2.5rem, 5vw, 3.35rem);
+  font-weight: 750;
 }
 
 h2,
 .heading-lg {
-  font-size: clamp(1.85rem, 3.5vw, 2.35rem);
+  font-size: clamp(1.95rem, 3.5vw, 2.5rem);
+  font-weight: 650;
 }
 
 h3,
 .heading-md {
-  font-size: clamp(1.45rem, 2.5vw, 1.9rem);
+  font-size: clamp(1.45rem, 2.8vw, 1.95rem);
+  font-weight: 600;
+  color: var(--color-muted);
 }
 
 h4,
 .heading-sm {
   font-size: 1.2rem;
+  font-weight: 600;
 }
 
 p {
   margin: 0 0 var(--space-4);
 }
 
-ul,
-ol {
-  margin: 0 0 var(--space-4);
-  padding-left: 1.35rem;
-}
-
-hr {
-  border: none;
-  border-top: 1px solid var(--color-border);
-  margin: var(--space-6) 0;
-}
-
-blockquote {
-  margin: var(--space-6) 0;
-  padding: var(--space-3) var(--space-4);
-  border-left: 3px solid var(--color-accent);
-  background-color: rgba(77, 184, 255, 0.16);
-  color: var(--color-text);
-  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  font-style: italic;
+strong {
+  font-weight: 650;
 }
 
 code,
 pre {
   font-family: var(--font-mono);
-  background-color: rgba(77, 184, 255, 0.08);
+  background-color: rgba(12, 30, 54, 0.65);
   color: var(--color-text);
 }
 
 code {
-  padding: 0.15em 0.35em;
-  border-radius: 0.35rem;
+  padding: 0.15em 0.45em;
+  border-radius: 0.45rem;
   border: 1px solid var(--color-border);
 }
 
@@ -192,6 +267,58 @@ pre {
   padding: var(--space-3);
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
+}
+
+pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+hr {
+  border: none;
+  height: 1px;
+  background: var(--gradient-divider);
+  border-radius: 999px;
+  margin: var(--space-7) 0;
+  position: relative;
+  overflow: visible;
+}
+
+hr::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: -0.5rem;
+  width: 5rem;
+  height: 1rem;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22120%22%20height%3D%2210%22%20fill%3D%22none%22%20viewBox%3D%220%200%20120%2010%22%3E%3Cpath%20d%3D%22M0%206C15%202%2030%202%2045%206C60%209%2075%209%2090%206C105%203%20110%202%20120%205%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.45%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+  opacity: 0.7;
+}
+
+blockquote {
+  margin: var(--space-7) 0;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-strong);
+  background: var(--gradient-quote);
+  color: var(--color-text);
+  position: relative;
+  overflow: hidden;
+}
+
+blockquote::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
 }
 
 /* Utility spacing helpers */
@@ -224,7 +351,7 @@ pre {
 .blog-index__intro {
   margin: 0 0 var(--space-6);
   max-width: 60ch;
-  color: var(--color-muted);
+  color: var(--color-subtle);
 }
 
 .post-grid {
@@ -247,15 +374,23 @@ pre {
 }
 
 .post-card {
-  background-color: var(--color-surface);
+  background: linear-gradient(135deg, rgba(26, 53, 95, 0.9), rgba(18, 39, 70, 0.95));
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-5), 2vw + 1rem, var(--space-6));
+  padding: clamp(var(--space-5), 2vw + 1.25rem, var(--space-6));
   display: grid;
   gap: var(--space-5);
   height: 100%;
   color: var(--color-text);
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.post-card:hover,
+.post-card:focus-within {
+  transform: translateY(-2px);
+  border-color: rgba(83, 220, 198, 0.45);
+  box-shadow: 0 36px 70px rgba(5, 18, 37, 0.6);
 }
 
 .post-card--with-image {
@@ -283,8 +418,9 @@ pre {
 
 .post-card__title {
   margin: 0;
-  font-size: clamp(1.65rem, 2.4vw, 2.05rem);
+  font-size: clamp(1.65rem, 2.4vw, 2.1rem);
   line-height: 1.25;
+  font-weight: 700;
 }
 
 .post-card__title a {
@@ -296,8 +432,8 @@ pre {
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2);
-  font-size: 0.9rem;
-  letter-spacing: 0.04em;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-subtle);
 }
@@ -362,10 +498,11 @@ pre {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-muted);
 }
 
 .pagination__link {
-  color: var(--color-accent);
+  color: var(--color-accent-secondary);
   font-weight: 600;
 }
 
@@ -379,23 +516,45 @@ pre {
 
 /* Post layout */
 .post {
-  background-color: var(--color-surface);
+  background: linear-gradient(135deg, rgba(20, 45, 80, 0.95), rgba(15, 34, 64, 0.92));
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-6), 4vw + 1rem, var(--space-8));
+  padding: clamp(var(--space-6), 4vw + 1.25rem, var(--space-9));
   display: grid;
   gap: var(--space-6);
   color: var(--color-text);
+  position: relative;
+  overflow: hidden;
 }
 
 .post__header {
   display: grid;
   gap: var(--space-4);
+  position: relative;
+  padding-bottom: var(--space-2);
+}
+
+.post__header::before {
+  content: "";
+  position: absolute;
+  inset: -30% -10% auto -10%;
+  height: 140%;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22220%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20220%22%3E%3Cpath%20d%3D%22M-20%20160C80%20120%20160%20200%20260%20160C340%20130%20380%20150%20460%20120%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.25%22/%3E%3Cpath%20d%3D%22M-10%20120C90%2080%20180%20140%20280%20110C360%2090%20420%20110%20500%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: cover;
+  opacity: 0.25;
+  pointer-events: none;
+}
+
+.post__header > * {
+  position: relative;
 }
 
 .post__title {
   margin: 0;
+  font-weight: 760;
+  line-height: 1.2;
 }
 
 .post__excerpt {
@@ -404,40 +563,349 @@ pre {
   font-size: 1.1rem;
 }
 
+.post__content-grid {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.post__content-column {
+  display: grid;
+  gap: var(--space-6);
+  align-content: start;
+}
+
 .post__body {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-5);
   font-size: 1.05rem;
-  line-height: 1.75;
+  line-height: 1.7;
   max-width: var(--max-reading-width);
   width: 100%;
   margin: 0 auto;
+  color: var(--color-text);
 }
 
 .post__body > * {
   margin: 0;
 }
 
-.post__disclaimer {
-  margin: 0 auto;
-  padding: var(--space-4);
+.post__body h2 {
+  margin-top: var(--space-7);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid rgba(83, 220, 198, 0.18);
+  position: relative;
+}
+
+.post__body h2::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  width: 3.5rem;
+  height: 3px;
+  background: var(--gradient-divider);
+  border-radius: 999px;
+}
+
+.post__body h2:first-of-type {
+  margin-top: var(--space-4);
+}
+
+.post__body h3 {
+  margin-top: var(--space-5);
+  padding-left: var(--space-3);
+  color: var(--color-subtle);
+  position: relative;
+  font-weight: 600;
+}
+
+.post__body h3::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.65rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.8), rgba(83, 220, 198, 0.6));
+  box-shadow: 0 0 0 4px rgba(77, 184, 255, 0.12);
+}
+
+.post__body h2,
+.post__body h3 {
+  scroll-margin-top: clamp(6rem, 7vw, 8rem);
+}
+
+.post__body a {
+  color: var(--color-accent-secondary);
+  text-decoration: underline;
+  text-decoration-color: rgba(83, 220, 198, 0.45);
+  font-weight: 500;
+}
+
+.post__body a:hover,
+.post__body a:focus {
+  color: var(--color-accent);
+  text-decoration-color: rgba(77, 184, 255, 0.55);
+}
+
+.post__body ul,
+.post__body ol {
+  list-style: none;
+  margin: 0 0 var(--space-5);
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.post__body li {
+  position: relative;
+  padding: calc(var(--space-3) + 0.15rem) var(--space-4) calc(var(--space-3) + 0.15rem) calc(var(--space-4) + 2.1rem);
+  background: rgba(15, 32, 58, 0.35);
+  border: 1px solid rgba(112, 158, 214, 0.24);
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  background-color: rgba(77, 184, 255, 0.12);
+  line-height: 1.65;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transition: border-color 150ms ease, transform 150ms ease;
+}
+
+.post__body li:hover {
+  border-color: rgba(83, 220, 198, 0.35);
+  transform: translateY(-1px);
+}
+
+.post__body li strong {
   color: var(--color-text);
+}
+
+.post__body li p:last-child {
+  margin-bottom: 0;
+}
+
+.post__body ul li::before {
+  content: "";
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(83, 220, 198, 0.25), transparent 70%),
+    url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%2214%22%20height%3D%2212%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2012%22%3E%3Cpath%20d%3D%22M1.5%206.5L4.8%209.5L12.5%201.5%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E") center/0.85rem 0.85rem no-repeat;
+}
+
+.post__body ol {
+  counter-reset: step;
+}
+
+.post__body ol li {
+  counter-increment: step;
+}
+
+.post__body ol li::before {
+  content: counter(step);
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.45), rgba(83, 220, 198, 0.45));
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 6px 12px rgba(5, 18, 37, 0.3);
+  font-variant-numeric: tabular-nums;
+}
+
+.post__body hr {
+  margin: var(--space-7) auto;
+}
+
+.post__body blockquote {
+  margin: var(--space-7) 0;
+}
+
+.post__disclaimer {
+  margin: var(--space-7) auto 0;
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(83, 220, 198, 0.28);
+  background: var(--color-surface-elevated);
+  color: var(--color-muted);
   font-size: 0.95rem;
   max-width: var(--max-reading-width);
   width: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.post__disclaimer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22160%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20160%22%3E%3Cpath%20d%3D%22M-40%20120C40%2090%20140%20140%20220%20110C300%2080%20340%20100%20440%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.2%22/%3E%3Cpath%20d%3D%22M-10%2090C70%2060%20140%2090%20240%2070C320%2060%20390%2080%20480%2060%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.4%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: cover;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.post__disclaimer > * {
+  position: relative;
+  margin: 0;
+}
+
+.post__toc {
+  display: none;
+}
+
+.post__toc-inner {
+  position: sticky;
+  top: clamp(5.5rem, 8vw, 7rem);
+  background: rgba(18, 39, 70, 0.85);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-xs);
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.post__toc-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-subtle);
+}
+
+.post__toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.post__toc-item--level-3 {
+  padding-left: var(--space-2);
+}
+
+.post__toc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-muted);
+  padding: 0.35rem 0;
+  border-left: 2px solid transparent;
+  transition: color 150ms ease, border-color 150ms ease;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.post__toc-link::before {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(77, 184, 255, 0.9), rgba(83, 220, 198, 0.7));
+  opacity: 0.6;
+}
+
+.post__toc-item--level-3 .post__toc-link {
+  font-size: 0.9rem;
+  color: rgba(201, 215, 242, 0.8);
+}
+
+.post__toc-item--level-3 .post__toc-link::before {
+  width: 0.35rem;
+  height: 0.35rem;
+  opacity: 0.5;
+}
+
+.post__toc-link:hover,
+.post__toc-link:focus {
+  color: var(--color-accent);
+  border-color: rgba(77, 184, 255, 0.45);
+}
+
+.post__toc-link:focus-visible {
+  outline: 2px solid rgba(83, 220, 198, 0.5);
+  outline-offset: 2px;
+}
+
+@media (min-width: 960px) {
+  .post__content-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, var(--toc-width));
+    align-items: start;
+    gap: var(--space-7);
+  }
+
+  .post__toc {
+    display: block;
+  }
+}
+
+@media (min-width: 900px) {
+  .post__body ol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-4);
+  }
+}
+
+@media (max-width: 960px) {
+  .post__content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .post__body ul,
+  .post__body ol {
+    gap: var(--space-2);
+  }
 }
 
 @media (max-width: 600px) {
   .post {
-    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-6));
+    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-7));
+  }
+
+  .post__body li {
+    padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 1.8rem);
+  }
+
+  .post__body ul li::before,
+  .post__body ol li::before {
+    left: var(--space-3);
   }
 }
 
-/* Empty state */
-.blog-list__empty {
-  font-style: italic;
-  color: var(--color-muted);
+/* Footer */
+footer .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+footer a {
+  color: var(--color-accent-secondary);
+}
+
+@media (max-width: 640px) {
+  footer .container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
 }

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)",
+  "description": "Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.",
+  "datePublished": "2025-09-15",
+  "dateModified": "2025-09-15",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)",
+      "item": "https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -110,11 +110,101 @@
 
 
   <link rel="stylesheet" href="/blog/static/style.css">
+  
+  
+  
+  
+    
+      
+    
+  
+  
+  
+  
+  
+  
+    
+  
+  
+  
+    
+  
+  
+  
+  
+    
+  
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Winter Gear Strategy: Coats, Boots, and Heavy Fabrics",
+  "description": "Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.",
+  "datePublished": "2025-09-20",
+  "dateModified": "2025-09-20",
+  "mainEntityOfPage": "https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "uPatch Travel Team"
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "Luggage Scale Blog",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://luggage-scale.com/blog/static/logo.svg"
+    }
+  },
+  "image": "https://luggage-scale.com/blog/static/logo.svg"
+}</script>
+  
+  <script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Luggage Scale Blog",
+      "item": "https://luggage-scale.com/blog/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Winter Gear Strategy: Coats, Boots, and Heavy Fabrics",
+      "item": "https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/"
+    }
+  ]
+}</script>
+  
 </head>
 <body class="post-page">
   <header class="site-header">
     <div class="container">
-      <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      <nav class="site-header__nav" aria-label="Primary">
+        <a class="site-header__brand" href="/blog/"><strong>Luggage Scale Blog</strong></a>
+      </nav>
+      
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <ol class="breadcrumbs__list">
+          
+          <li class="breadcrumbs__item">
+            
+            <a href="/blog/">Luggage Scale Blog</a>
+            
+          </li>
+          
+          <li class="breadcrumbs__item">
+            
+            <span aria-current="page">Winter Gear Strategy: Coats, Boots, and Heavy Fabrics</span>
+            
+          </li>
+          
+        </ol>
+      </nav>
+      
     </div>
   </header>
 
@@ -134,22 +224,23 @@
           
         </div>
         
-        
         <p class="post__excerpt">Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.</p>
         
       </header>
 
-      <div class="post__body">
-        <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-<h2>Why it matters</h2>
+      <div class="post__content-grid">
+        <div class="post__content-column">
+          <div class="post__body">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
+<h2 id="why-it-matters">Why it matters</h2>
 <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
-<h2>What you’ll need</h2>
+<h2 id="what-youll-need">What you’ll need</h2>
 <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
-<h2>Steps</h2>
+<h2 id="steps">Steps</h2>
 <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
@@ -158,24 +249,69 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
-<h2>Pro tips</h2>
+<h2 id="pro-tips">Pro tips</h2>
 <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
-<h2>After you weigh</h2>
+<h2 id="after-you-weigh">After you weigh</h2>
 <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
 
-      </div>
+          </div>
 
-      
-      <aside class="post__disclaimer">
-        This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
-      </aside>
-      
+          
+          <aside class="post__disclaimer">
+            This article may contain affiliate links. If you make a purchase through these links, we may earn a small commission at no extra cost to you.
+          </aside>
+          
+        </div>
+
+        
+        <aside class="post__toc" aria-labelledby="on-this-page">
+          <div class="post__toc-inner">
+            <h2 id="on-this-page" class="post__toc-title">On this page</h2>
+            <nav class="post__toc-nav" aria-label="On this page">
+              <ol class="post__toc-list">
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#why-it-matters">Why it matters</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#what-youll-need">What you’ll need</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#steps">Steps</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#pro-tips">Pro tips</a>
+                </li>
+                
+                
+                
+                <li class="post__toc-item post__toc-item--level-2">
+                  <a class="post__toc-link" href="#after-you-weigh">After you weigh</a>
+                </li>
+                
+                
+              </ol>
+            </nav>
+          </div>
+        </aside>
+        
+      </div>
     </article>
   </main>
 


### PR DESCRIPTION
## Summary
- add Eleventy helpers to slug post headings, expose JSON-LD data, and normalize breadcrumb URLs
- rebuild the post layout with breadcrumb navigation, a sticky "On this page" table of contents, and improved disclaimer placement
- refresh the global blog styling with Plus Jakarta Sans, larger rhythm, iconified lists, and updated card spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0bf8adab483329e85982c5fa4aaa1