### PR TITLE
Revamp blog layout with new style guide

### DIFF
--- a/blog-src/_includes/blog-list.njk
+++ b/blog-src/_includes/blog-list.njk
@@ -8,7 +8,7 @@
       {% set summaryText %}{{ post.templateContent | striptags | truncate(200, true, "…") }}{% endset %}
     {% endif %}
     {% set hasHero = post.data.heroImage %}
-    <li>
+    <li class="post-grid__item">
       <article class="post-card{% if hasHero %} post-card--with-image{% endif %}">
         {% if hasHero %}
         <a class="post-card__media" href="{{ post.url }}">
@@ -35,7 +35,9 @@
           {% if summaryText %}
           <p class="post-card__excerpt">{{ summaryText }}</p>
           {% endif %}
-          <a class="post-card__cta" href="{{ post.url }}">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="{{ post.url }}">Read the article</a>
+          </div>
         </div>
       </article>
     </li>

--- a/blog-src/_includes/blog.njk
+++ b/blog-src/_includes/blog.njk
@@ -20,33 +20,57 @@ permalink: "index.html"
   } %}
   {% set site = headSite %}
   {% include "head.njk" %}
+  <link rel="stylesheet" href="{{ config.site.base }}/static/style.css">
 </head>
-<body>
-  <header>
-    <h1>Luggage Scale Blog</h1>
+<body class="blog-index">
+  <header class="site-header">
+    <div class="container">
+      <div class="site-header__nav">
+        <a class="site-header__brand" href="{{ config.site.base }}/">{{ config.site.name }}</a>
+        <nav class="site-nav" aria-label="Primary navigation">
+          <a href="{{ config.site.base }}/">Blog Home</a>
+          <a href="{{ config.site.base }}/page-2/">Archive</a>
+          <a href="{{ config.site.base }}/sitemap.xml">Sitemap</a>
+        </nav>
+      </div>
+    </div>
   </header>
 
-  <main>
-    <h2>Latest Posts</h2>
-    <ul>
-      {% for post in pagination.items %}
-        <li>
-          <a href="{{ post.url }}">{{ post.data.title }}</a>
-          — {{ post.date | date("MMMM D, YYYY") }}
-        </li>
-      {% endfor %}
-    </ul>
+  <main class="site-main">
+    <div class="container">
+      <section class="page-intro">
+        <h1 class="page-title">Luggage Scale Blog</h1>
+        <p class="page-lede">Latest articles, guides, and tips from the uPatch luggage scale team.</p>
+        <div class="btn-group">
+          <a class="btn solid" href="#latest-posts">Read the latest</a>
+          <a class="btn outline" href="{{ config.site.base }}/page-2/">View the archive</a>
+        </div>
+      </section>
 
-    {% if pagination.href.previous %}
-      <a href="{{ pagination.href.previous }}">Newer</a>
-    {% endif %}
-    {% if pagination.href.next %}
-      <a href="{{ pagination.href.next }}">Older →</a>
-    {% endif %}
+      <section class="post-feed" id="latest-posts">
+        <div>
+          <h2 class="section-title">Latest Posts</h2>
+        </div>
+        {% include "blog-list.njk" with { postsCollection: pagination.items } %}
+      </section>
+
+      {% if pagination.href.previous or pagination.href.next %}
+      <nav class="pagination" aria-label="Blog pagination">
+        {% if pagination.href.previous %}
+        <a class="btn outline" href="{{ pagination.href.previous }}">← Newer Posts</a>
+        {% endif %}
+        {% if pagination.href.next %}
+        <a class="btn solid" href="{{ pagination.href.next }}">Older Posts →</a>
+        {% endif %}
+      </nav>
+      {% endif %}
+    </div>
   </main>
 
-  <footer>
-    <p>© {{ now | date("YYYY") }} — <a href="/blog/">Blog Index</a> • <a href="/blog/sitemap.xml">Sitemap</a></p>
+  <footer class="site-footer">
+    <div class="container">
+      <p>© {{ now | date("YYYY") }} — <a href="{{ config.site.base }}/">Blog Index</a> • <a href="{{ config.site.base }}/sitemap.xml">Sitemap</a></p>
+    </div>
   </footer>
 </body>
 </html>

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -1,145 +1,296 @@
-@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
 
-/* Blog design tokens */
 :root {
-  color-scheme: dark;
-  --font-sans: "Plus Jakarta Sans", "InterVariable", "Inter var", "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --color-bg: #071427;
-  --color-surface: #122746;
-  --color-surface-soft: #18335c;
-  --color-surface-elevated: rgba(21, 44, 78, 0.82);
-  --color-text: #f3f8ff;
-  --color-muted: #c9d7f2;
-  --color-subtle: #8aa3c3;
-  --color-border: rgba(112, 158, 214, 0.28);
-  --color-border-strong: rgba(112, 158, 214, 0.45);
-  --color-accent: #4db8ff;
-  --color-accent-secondary: #53dcc6;
-  --color-accent-soft: rgba(83, 220, 198, 0.2);
-  --shadow-xs: 0 10px 24px rgba(3, 12, 26, 0.35);
-  --shadow-sm: 0 32px 70px rgba(5, 18, 37, 0.55);
-  --radius-sm: 0.65rem;
-  --radius-md: 0.95rem;
-  --max-reading-width: 72ch;
-  --toc-width: 19rem;
-  --gradient-divider: linear-gradient(90deg, rgba(83, 220, 198, 0.4) 0%, rgba(77, 184, 255, 0.35) 100%);
-  --gradient-quote: linear-gradient(135deg, rgba(83, 220, 198, 0.22), rgba(77, 184, 255, 0.16));
-  --space-0: 0;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
-  --space-7: 3rem;
-  --space-8: 4rem;
-  --space-9: 5rem;
+  --color-blue: #002f5f;
+  --color-red: #c62828;
+  --color-white: #ffffff;
+  --color-body: #333333;
+  --color-muted: #6b7280;
+  --color-border: rgba(0, 47, 95, 0.18);
+  --color-border-strong: rgba(0, 47, 95, 0.28);
+  --shadow-card: 0 18px 34px rgba(0, 47, 95, 0.14);
+  --shadow-soft: 0 10px 20px rgba(0, 47, 95, 0.1);
+  --radius-card: 1rem;
+  --radius-pill: 999px;
+  --max-site-width: 72rem;
+  --max-content-width: 44rem;
+  --transition-fast: 180ms ease;
 }
 
-/* Base layout */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 100%;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: var(--font-sans);
-  font-size: clamp(1.05rem, 1rem + 0.25vw, 1.1rem);
-  line-height: 1.7;
-  background: radial-gradient(120% 120% at 50% 0%, rgba(24, 52, 96, 0.45), transparent 55%), var(--color-bg);
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  -webkit-font-smoothing: antialiased;
+  font-family: "Inter", "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--color-body);
+  background-color: var(--color-white);
   text-rendering: optimizeLegibility;
-  font-feature-settings: "liga" 1, "kern" 1;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  display: block;
+}
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: calc(var(--radius-card) - 0.25rem);
+}
+
+figure {
+  margin: 0 0 1.5rem;
+}
+
+figcaption {
+  margin-top: 0.75rem;
+  font-size: 0.9375rem;
+  color: var(--color-muted);
+}
+
+p,
+ul,
+ol,
+blockquote,
+pre,
+table {
+  margin: 0 0 1.5rem;
+}
+
+ul,
+ol {
+  padding-left: 1.4rem;
+}
+
+li + li {
+  margin-top: 0.35rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-blue);
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 1rem;
+}
+
+h1 {
+  font-size: clamp(2.25rem, 2rem + 1vw, 3rem);
+}
+
+h2 {
+  font-size: clamp(1.75rem, 1.5rem + 0.6vw, 2.25rem);
+}
+
+h3 {
+  font-size: clamp(1.5rem, 1.35rem + 0.4vw, 1.875rem);
+}
+
+h4 {
+  font-size: clamp(1.25rem, 1.15rem + 0.2vw, 1.5rem);
 }
 
 a {
-  color: var(--color-accent-secondary);
-  text-decoration: none;
+  color: var(--color-blue);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: rgba(0, 47, 95, 0.35);
   font-weight: 500;
-  transition: color 150ms ease, text-decoration-color 150ms ease;
+  transition: color var(--transition-fast), text-decoration-color var(--transition-fast);
 }
 
 a:hover,
 a:focus {
-  color: var(--color-accent);
-  text-decoration: underline;
-  text-decoration-color: currentColor;
+  color: var(--color-red);
+  text-decoration-color: rgba(198, 40, 40, 0.75);
 }
 
-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-  border-radius: var(--radius-sm);
+a:focus-visible,
+button:focus-visible,
+.btn:focus-visible {
+  outline: 3px solid rgba(198, 40, 40, 0.45);
+  outline-offset: 3px;
 }
 
-.icon {
-  width: 1.1em;
-  height: 1.1em;
-  display: inline-block;
-  flex-shrink: 0;
-  color: var(--color-accent-secondary);
-  vertical-align: middle;
+code,
+pre {
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: rgba(0, 47, 95, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.15rem 0.35rem;
+}
+
+pre {
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+}
+
+blockquote {
+  border-left: 0.3rem solid var(--color-red);
+  background: rgba(198, 40, 40, 0.08);
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius-card);
+  font-style: italic;
+}
+
+blockquote p {
+  margin-bottom: 0.75rem;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.pullquote {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.callout {
+  border: 2px dashed rgba(0, 47, 95, 0.25);
+  background: rgba(0, 47, 95, 0.06);
+  padding: 1.5rem;
+  border-radius: var(--radius-card);
+}
+
+hr {
+  border: none;
+  border-top: 1px solid rgba(0, 47, 95, 0.12);
+  margin: 2.5rem 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  background: var(--color-white);
+  box-shadow: var(--shadow-soft);
+}
+
+thead {
+  background: rgba(0, 47, 95, 0.08);
+}
+
+thead th {
+  color: var(--color-blue);
+  font-weight: 600;
+}
+
+th,
+td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 47, 95, 0.12);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(0, 47, 95, 0.03);
 }
 
 .container {
-  width: min(100%, 78rem);
+  width: 100%;
+  max-width: var(--max-site-width);
   margin: 0 auto;
-  padding-left: clamp(1.5rem, 4vw, 3.5rem);
-  padding-right: clamp(1.5rem, 4vw, 3.5rem);
+  padding: 0 1.5rem;
 }
 
 .site-header {
-  background: rgba(18, 39, 70, 0.92);
-  backdrop-filter: blur(18px);
-  padding: var(--space-5) 0 var(--space-4);
-  border-bottom: 1px solid rgba(112, 158, 214, 0.25);
-  margin-bottom: var(--space-7);
-  box-shadow: var(--shadow-xs);
-  position: relative;
-  z-index: 1;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.97);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: 0 4px 20px rgba(0, 47, 95, 0.08);
 }
 
-footer {
-  background: rgba(18, 39, 70, 0.9);
-  padding: var(--space-6) 0;
-  border-top: 1px solid rgba(112, 158, 214, 0.2);
-  margin-top: var(--space-8);
-  font-size: 0.95rem;
-  color: var(--color-subtle);
-  box-shadow: var(--shadow-xs);
-}
-
-main {
-  padding: var(--space-7) 0 var(--space-8);
+.site-header .container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 }
 
 .site-header__nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .site-header__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: 1.1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-text);
+  font-size: 1.2rem;
   font-weight: 700;
+  color: var(--color-blue);
+  text-decoration: none;
 }
 
 .site-header__brand:hover,
 .site-header__brand:focus {
-  color: var(--color-accent);
+  color: var(--color-red);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  position: relative;
+  color: var(--color-blue);
+  text-decoration: none;
+  font-weight: 600;
+  padding-bottom: 0.2rem;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: transparent;
+  transition: background var(--transition-fast);
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus::after {
+  background: var(--color-red);
 }
 
 .breadcrumbs {
-  margin-top: var(--space-3);
-  font-size: 0.95rem;
-  color: var(--color-subtle);
+  font-size: 0.9375rem;
+  color: var(--color-muted);
 }
 
 .breadcrumbs__list {
@@ -148,643 +299,277 @@ main {
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.breadcrumbs__item {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.breadcrumbs__item:not(:last-child)::after {
-  content: "›";
-  opacity: 0.5;
-  color: var(--color-subtle);
-  font-size: 1rem;
+  gap: 0.5rem;
 }
 
 .breadcrumbs__item a {
-  color: var(--color-accent-secondary);
-  font-weight: 500;
-}
-
-.breadcrumbs__item span[aria-current="page"] {
+  text-decoration: none;
   color: var(--color-muted);
-  font-weight: 500;
 }
 
-@media (max-width: 768px) {
-  .container {
-    padding-left: clamp(1.25rem, 6vw, 2rem);
-    padding-right: clamp(1.25rem, 6vw, 2rem);
-  }
-
-  .site-header {
-    margin-bottom: var(--space-6);
-  }
-
-  main {
-    padding: var(--space-6) 0 var(--space-7);
-  }
+.breadcrumbs__item a:hover,
+.breadcrumbs__item a:focus {
+  color: var(--color-red);
+  text-decoration: underline;
 }
 
-@media (max-width: 520px) {
-  .breadcrumbs {
-    font-size: 0.9rem;
-  }
+.site-main {
+  padding: 4rem 0 5rem;
 }
 
-@media (min-width: 1200px) {
-  .container {
-    width: min(100%, 84rem);
-    padding-left: clamp(2.5rem, 6vw, 4.5rem);
-    padding-right: clamp(2.5rem, 6vw, 4.5rem);
-  }
+main.container {
+  padding-top: 4rem;
+  padding-bottom: 5rem;
 }
 
-/* Typography */
-h1,
-h2,
-h3,
-h4 {
-  margin: 0 0 var(--space-3);
+.page-intro {
+  max-width: 40rem;
+  display: grid;
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.page-lede {
+  font-size: 1.05rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.btn-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+  padding: 0.65rem 1.1rem;
   line-height: 1.2;
-  color: var(--color-text);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  text-decoration: none;
+  box-sizing: border-box;
+  min-height: 2.75rem;
 }
 
-h1,
-.heading-xl {
-  font-size: clamp(2.5rem, 5vw, 3.35rem);
-  font-weight: 750;
+.btn:active {
+  transform: translateY(1px);
 }
 
-h2,
-.heading-lg {
-  font-size: clamp(1.95rem, 3.5vw, 2.5rem);
-  font-weight: 650;
+.btn.solid {
+  background: var(--color-blue);
+  color: var(--color-white);
+  border-color: var(--color-blue);
 }
 
-h3,
-.heading-md {
-  font-size: clamp(1.45rem, 2.8vw, 1.95rem);
-  font-weight: 600;
-  color: var(--color-muted);
+.btn.solid:hover,
+.btn.solid:focus {
+  background: var(--color-red);
+  border-color: var(--color-red);
 }
 
-h4,
-.heading-sm {
-  font-size: 1.2rem;
-  font-weight: 600;
+.btn.outline {
+  background: var(--color-white);
+  color: var(--color-blue);
+  border-color: var(--color-blue);
 }
 
-p {
-  margin: 0 0 var(--space-4);
+.btn.outline:hover,
+.btn.outline:focus {
+  background: var(--color-red);
+  color: var(--color-white);
+  border-color: var(--color-red);
 }
 
-strong {
-  font-weight: 650;
+.section-title {
+  margin-bottom: 1.5rem;
 }
 
-code,
-pre {
-  font-family: var(--font-mono);
-  background-color: rgba(12, 30, 54, 0.65);
-  color: var(--color-text);
-}
-
-code {
-  padding: 0.15em 0.45em;
-  border-radius: 0.45rem;
-  border: 1px solid var(--color-border);
-}
-
-pre {
-  overflow-x: auto;
-  padding: var(--space-3);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-}
-
-pre code {
-  background: transparent;
-  border: 0;
-  padding: 0;
-}
-
-hr {
-  border: none;
-  height: 1px;
-  background: var(--gradient-divider);
-  border-radius: 999px;
-  margin: var(--space-7) 0;
-  position: relative;
-  overflow: visible;
-}
-
-hr::after {
-  content: "";
-  position: absolute;
-  right: 0;
-  top: -0.5rem;
-  width: 5rem;
-  height: 1rem;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22120%22%20height%3D%2210%22%20fill%3D%22none%22%20viewBox%3D%220%200%20120%2010%22%3E%3Cpath%20d%3D%22M0%206C15%202%2030%202%2045%206C60%209%2075%209%2090%206C105%203%20110%202%20120%205%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.45%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-size: contain;
-  opacity: 0.7;
-}
-
-blockquote {
-  margin: var(--space-7) 0;
-  padding: var(--space-4) var(--space-5);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border-strong);
-  background: var(--gradient-quote);
-  color: var(--color-text);
-  position: relative;
-  overflow: hidden;
-}
-
-blockquote::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.12), transparent 60%);
-  pointer-events: none;
-}
-
-blockquote p:last-child {
-  margin-bottom: 0;
-}
-
-/* Utility spacing helpers */
-.stack-xs > * + * {
-  margin-top: var(--space-2);
-}
-
-.stack-sm > * + * {
-  margin-top: var(--space-3);
-}
-
-.stack-md > * + * {
-  margin-top: var(--space-4);
-}
-
-.stack-lg > * + * {
-  margin-top: var(--space-6);
-}
-
-.text-muted {
-  color: var(--color-muted);
-}
-
-/* Blog listing */
-.blog-index__title {
-  margin: 0 0 var(--space-2);
-  color: var(--color-text);
-}
-
-.blog-index__intro {
-  margin: 0 0 var(--space-6);
-  max-width: 60ch;
-  color: var(--color-subtle);
+.post-feed {
+  display: grid;
+  gap: 2.5rem;
 }
 
 .post-grid {
+  display: grid;
+  gap: 1.75rem;
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: clamp(var(--space-5), 3vw, var(--space-6));
-  grid-template-columns: 1fr;
 }
 
-.post-grid > li {
-  margin: 0;
-}
-
-@media (min-width: 40rem) {
-  .post-grid {
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
-  }
+.post-grid__item {
+  display: flex;
 }
 
 .post-card {
-  background: linear-gradient(135deg, rgba(26, 53, 95, 0.9), rgba(18, 39, 70, 0.95));
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-5), 2vw + 1.25rem, var(--space-6));
-  display: grid;
-  gap: var(--space-5);
-  height: 100%;
-  color: var(--color-text);
-  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+  background: var(--color-white);
+  border-radius: var(--radius-card);
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  width: 100%;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .post-card:hover,
 .post-card:focus-within {
-  transform: translateY(-2px);
-  border-color: rgba(83, 220, 198, 0.45);
-  box-shadow: 0 36px 70px rgba(5, 18, 37, 0.6);
-}
-
-.post-card--with-image {
-  align-items: center;
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card);
 }
 
 .post-card__media {
   display: block;
-  border-radius: calc(var(--radius-md) - var(--space-1));
   overflow: hidden;
-  aspect-ratio: 16 / 9;
-  background-color: rgba(77, 184, 255, 0.12);
 }
 
 .post-card__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  aspect-ratio: 16 / 9;
+  border-radius: 0;
 }
 
 .post-card__body {
-  display: grid;
-  gap: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.75rem;
 }
 
 .post-card__title {
   margin: 0;
-  font-size: clamp(1.65rem, 2.4vw, 2.1rem);
-  line-height: 1.25;
-  font-weight: 700;
+  font-size: 1.45rem;
 }
 
 .post-card__title a {
-  color: inherit;
+  text-decoration: none;
+}
+
+.post-card__title a:hover,
+.post-card__title a:focus {
+  color: var(--color-red);
 }
 
 .post-meta {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: 0.85rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-subtle);
-}
-
-.post-meta__author,
-.post-meta__date {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
+  gap: 0.35rem 0.6rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  margin: 0;
 }
 
 .post-meta__separator {
-  color: var(--color-subtle);
+  color: rgba(0, 47, 95, 0.35);
 }
 
 .post-card__excerpt {
   margin: 0;
-  color: var(--color-muted);
-}
-
-.post-card__cta {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 600;
-  color: var(--color-accent);
-}
-
-.post-card__cta:hover,
-.post-card__cta:focus {
-  text-decoration: underline;
-}
-
-.post-card__cta-icon {
-  transition: transform 150ms ease;
-}
-
-.post-card__cta:hover .post-card__cta-icon,
-.post-card__cta:focus .post-card__cta-icon {
-  transform: translateX(0.2rem);
-}
-
-@media (min-width: 768px) {
-  .post-card--with-image {
-    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.45fr);
-  }
-}
-
-@media (max-width: 600px) {
-  .post-card {
-    padding: var(--space-5);
-  }
-
-  .post-card--with-image {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-/* Pagination */
-.pagination {
-  margin-top: var(--space-7);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: var(--color-muted);
-}
-
-.pagination__link {
-  color: var(--color-accent-secondary);
-  font-weight: 600;
-}
-
-.pagination__link--prev {
-  margin-right: auto;
-}
-
-.pagination__link--next {
-  margin-left: auto;
-}
-
-/* Post layout */
-.post {
-  background: linear-gradient(135deg, rgba(20, 45, 80, 0.95), rgba(15, 34, 64, 0.92));
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-6), 4vw + 1.25rem, var(--space-9));
-  display: grid;
-  gap: var(--space-6);
-  color: var(--color-text);
-  position: relative;
+  color: var(--color-body);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
+.post-card__actions {
+  margin-top: auto;
+}
+
+.post-card__cta {
+  align-self: flex-start;
+}
+
+.blog-list__empty {
+  padding: 2rem;
+  border-radius: var(--radius-card);
+  border: 1px dashed rgba(0, 47, 95, 0.3);
+  text-align: center;
+  background: rgba(0, 47, 95, 0.05);
+}
+
+.post {
+  background: var(--color-white);
+  border-radius: var(--radius-card);
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.75rem, 1.5rem + 1vw, 3rem);
+  max-width: calc(var(--max-content-width) + 20rem);
+  margin: 0 auto;
+}
+
 .post__header {
-  display: grid;
-  gap: var(--space-4);
-  position: relative;
-  padding-bottom: var(--space-2);
-}
-
-.post__header::before {
-  content: "";
-  position: absolute;
-  inset: -30% -10% auto -10%;
-  height: 140%;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22220%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20220%22%3E%3Cpath%20d%3D%22M-20%20160C80%20120%20160%20200%20260%20160C340%20130%20380%20150%20460%20120%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.25%22/%3E%3Cpath%20d%3D%22M-10%20120C90%2080%20180%20140%20280%20110C360%2090%20420%20110%20500%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-size: cover;
-  opacity: 0.25;
-  pointer-events: none;
-}
-
-.post__header > * {
-  position: relative;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(0, 47, 95, 0.12);
+  margin-bottom: 2rem;
 }
 
 .post__title {
-  margin: 0;
-  font-weight: 760;
-  line-height: 1.2;
+  margin-bottom: 0.75rem;
 }
 
 .post__excerpt {
   margin: 0;
   color: var(--color-muted);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 
 .post__content-grid {
-  display: grid;
-  gap: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
 .post__content-column {
-  display: grid;
-  gap: var(--space-6);
-  align-content: start;
-}
-
-.post__body {
-  display: grid;
-  gap: var(--space-5);
-  font-size: 1.05rem;
-  line-height: 1.7;
-  max-width: var(--max-reading-width);
+  max-width: var(--max-content-width);
   width: 100%;
-  margin: 0 auto;
-  color: var(--color-text);
 }
 
 .post__body > * {
-  margin: 0;
+  margin-top: 0;
 }
 
-.post__body h2 {
-  margin-top: var(--space-7);
-  padding-bottom: var(--space-2);
-  border-bottom: 1px solid rgba(83, 220, 198, 0.18);
-  position: relative;
-}
-
-.post__body h2::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -1px;
-  width: 3.5rem;
-  height: 3px;
-  background: var(--gradient-divider);
-  border-radius: 999px;
-}
-
-.post__body h2:first-of-type {
-  margin-top: var(--space-4);
-}
-
-.post__body h3 {
-  margin-top: var(--space-5);
-  padding-left: var(--space-3);
-  color: var(--color-subtle);
-  position: relative;
-  font-weight: 600;
-}
-
-.post__body h3::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.65rem;
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.8), rgba(83, 220, 198, 0.6));
-  box-shadow: 0 0 0 4px rgba(77, 184, 255, 0.12);
+.post__body > * + * {
+  margin-top: 1.75rem;
 }
 
 .post__body h2,
-.post__body h3 {
-  scroll-margin-top: clamp(6rem, 7vw, 8rem);
-}
-
-.post__body a {
-  color: var(--color-accent-secondary);
-  text-decoration: underline;
-  text-decoration-color: rgba(83, 220, 198, 0.45);
-  font-weight: 500;
-}
-
-.post__body a:hover,
-.post__body a:focus {
-  color: var(--color-accent);
-  text-decoration-color: rgba(77, 184, 255, 0.55);
+.post__body h3,
+.post__body h4 {
+  margin-top: 2.5rem;
 }
 
 .post__body ul,
 .post__body ol {
-  list-style: none;
-  margin: 0 0 var(--space-5);
-  padding: 0;
-  display: grid;
-  gap: var(--space-3);
-}
-
-.post__body li {
-  position: relative;
-  padding: calc(var(--space-3) + 0.15rem) var(--space-4) calc(var(--space-3) + 0.15rem) calc(var(--space-4) + 2.1rem);
-  background: rgba(15, 32, 58, 0.35);
-  border: 1px solid rgba(112, 158, 214, 0.24);
-  border-radius: var(--radius-sm);
-  line-height: 1.65;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  transition: border-color 150ms ease, transform 150ms ease;
-}
-
-.post__body li:hover {
-  border-color: rgba(83, 220, 198, 0.35);
-  transform: translateY(-1px);
-}
-
-.post__body li strong {
-  color: var(--color-text);
-}
-
-.post__body li p:last-child {
-  margin-bottom: 0;
-}
-
-.post__body ul li::before {
-  content: "";
-  position: absolute;
-  left: var(--space-3);
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 1.6rem;
-  height: 1.6rem;
-  border-radius: 999px;
-  background:
-    radial-gradient(circle at 50% 50%, rgba(83, 220, 198, 0.25), transparent 70%),
-    url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%2214%22%20height%3D%2212%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2012%22%3E%3Cpath%20d%3D%22M1.5%206.5L4.8%209.5L12.5%201.5%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E") center/0.85rem 0.85rem no-repeat;
-}
-
-.post__body ol {
-  counter-reset: step;
-}
-
-.post__body ol li {
-  counter-increment: step;
-}
-
-.post__body ol li::before {
-  content: counter(step);
-  position: absolute;
-  left: var(--space-3);
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 1.95rem;
-  height: 1.95rem;
-  border-radius: 50%;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.45), rgba(83, 220, 198, 0.45));
-  color: var(--color-text);
-  font-weight: 600;
-  font-size: 0.9rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 6px 12px rgba(5, 18, 37, 0.3);
-  font-variant-numeric: tabular-nums;
-}
-
-.post__body hr {
-  margin: var(--space-7) auto;
-}
-
-.post__body blockquote {
-  margin: var(--space-7) 0;
-}
-
-.post__disclaimer {
-  margin: var(--space-7) auto 0;
-  padding: var(--space-4) var(--space-5);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(83, 220, 198, 0.28);
-  background: var(--color-surface-elevated);
-  color: var(--color-muted);
-  font-size: 0.95rem;
-  max-width: var(--max-reading-width);
-  width: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.post__disclaimer::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22160%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20160%22%3E%3Cpath%20d%3D%22M-40%20120C40%2090%20140%20140%20220%20110C300%2080%20340%20100%20440%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.2%22/%3E%3Cpath%20d%3D%22M-10%2090C70%2060%20140%2090%20240%2070C320%2060%20390%2080%20480%2060%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.4%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-size: cover;
-  opacity: 0.35;
-  pointer-events: none;
-}
-
-.post__disclaimer > * {
-  position: relative;
-  margin: 0;
+  padding-left: 1.5rem;
 }
 
 .post__toc {
-  display: none;
+  position: static;
 }
 
 .post__toc-inner {
-  position: sticky;
-  top: clamp(5.5rem, 8vw, 7rem);
-  background: rgba(18, 39, 70, 0.85);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  box-shadow: var(--shadow-xs);
-  backdrop-filter: blur(12px);
-  display: grid;
-  gap: var(--space-3);
+  background: rgba(0, 47, 95, 0.03);
+  border-radius: var(--radius-card);
+  padding: 1.5rem;
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: var(--shadow-soft);
 }
 
 .post__toc-title {
-  margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-subtle);
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
 }
 
 .post__toc-list {
@@ -792,120 +577,140 @@ blockquote p:last-child {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: var(--space-2);
+  gap: 0.65rem;
 }
 
 .post__toc-item--level-3 {
-  padding-left: var(--space-2);
+  padding-left: 1rem;
 }
 
 .post__toc-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--color-muted);
-  padding: 0.35rem 0;
-  border-left: 2px solid transparent;
-  transition: color 150ms ease, border-color 150ms ease;
   text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.post__toc-link::before {
-  content: "";
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.9), rgba(83, 220, 198, 0.7));
-  opacity: 0.6;
-}
-
-.post__toc-item--level-3 .post__toc-link {
-  font-size: 0.9rem;
-  color: rgba(201, 215, 242, 0.8);
-}
-
-.post__toc-item--level-3 .post__toc-link::before {
-  width: 0.35rem;
-  height: 0.35rem;
-  opacity: 0.5;
+  color: var(--color-blue);
+  font-weight: 500;
 }
 
 .post__toc-link:hover,
 .post__toc-link:focus {
-  color: var(--color-accent);
-  border-color: rgba(77, 184, 255, 0.45);
+  color: var(--color-red);
+  text-decoration: underline;
 }
 
-.post__toc-link:focus-visible {
-  outline: 2px solid rgba(83, 220, 198, 0.5);
-  outline-offset: 2px;
+.post__disclaimer {
+  margin-top: 2.5rem;
+  padding: 1.25rem 1.5rem;
+  background: rgba(0, 47, 95, 0.05);
+  border-radius: var(--radius-card);
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  font-size: 0.95rem;
 }
 
-@media (min-width: 960px) {
-  .post__content-grid {
-    grid-template-columns: minmax(0, 1fr) minmax(0, var(--toc-width));
-    align-items: start;
-    gap: var(--space-7);
+.pagination {
+  margin-top: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.pagination__info {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.site-footer,
+footer {
+  background: var(--color-blue);
+  color: var(--color-white);
+  padding: 2.5rem 0;
+  margin-top: 4rem;
+}
+
+.site-footer a,
+footer a {
+  color: var(--color-white);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus,
+footer a:hover,
+footer a:focus {
+  color: var(--color-red);
+}
+
+.post-page .site-main {
+  padding-top: 3.5rem;
+}
+
+.post-page main.container {
+  padding-top: 3.5rem;
+}
+
+@media (min-width: 480px) {
+  .page-intro {
+    margin-bottom: 3.5rem;
+  }
+}
+
+@media (min-width: 640px) {
+  .post-grid {
+    grid-template-columns: repeat(auto-fit, minmax(18.5rem, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  body {
+    font-size: 1.0625rem;
   }
 
-  .post__toc {
-    display: block;
+  .site-main {
+    padding: 4.5rem 0 5.5rem;
+  }
+
+  .page-intro {
+    gap: 1.5rem;
   }
 }
 
 @media (min-width: 900px) {
-  .post__body ol {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-4);
-  }
-}
-
-@media (max-width: 960px) {
-  .post__content-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 720px) {
-  .post__body ul,
-  .post__body ol {
-    gap: var(--space-2);
-  }
-}
-
-@media (max-width: 600px) {
-  .post {
-    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-7));
-  }
-
-  .post__body li {
-    padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 1.8rem);
-  }
-
-  .post__body ul li::before,
-  .post__body ol li::before {
-    left: var(--space-3);
-  }
-}
-
-/* Footer */
-footer .container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-footer a {
-  color: var(--color-accent-secondary);
-}
-
-@media (max-width: 640px) {
-  footer .container {
+  .site-header .container {
     flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-2);
+    align-items: stretch;
+  }
+
+  .post {
+    padding: clamp(2.5rem, 2rem + 1vw, 3.5rem);
+  }
+
+  .post__content-grid {
+    display: grid;
+    grid-template-columns: minmax(0, var(--max-content-width)) minmax(16rem, 20rem);
+    gap: 3rem;
+    align-items: start;
+  }
+
+  .post__toc {
+    position: sticky;
+    top: 7.5rem;
+  }
+}
+
+@media (min-width: 1100px) {
+  .site-header .container {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -144,7 +144,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -167,7 +167,9 @@
           
           <p class="post-card__excerpt">Balance heavy coats, boots, and layers by using a luggage scale to dial in winter travel packing.</p>
           
-          <a class="post-card__cta" href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -176,7 +178,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -199,7 +201,9 @@
           
           <p class="post-card__excerpt">Build a repeatable weekly packing routine that keeps your carry-on within airline limits without last-minute stress.</p>
           
-          <a class="post-card__cta" href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/business-travel-weekly-packing-system-to-eliminate-overages/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -208,7 +212,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -231,7 +235,9 @@
           
           <p class="post-card__excerpt">Quick home calibration checks help you trust every luggage scale reading before you roll to the airport.</p>
           
-          <a class="post-card__cta" href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -240,7 +246,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -263,7 +269,9 @@
           
           <p class="post-card__excerpt">A quick welcome post introducing the uPatch luggage scale blog and what we&#39;ll be sharing.</p>
           
-          <a class="post-card__cta" href="/blog/hello-world/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/hello-world/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -272,7 +280,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -295,7 +303,9 @@
           
           <p class="post-card__excerpt">Plan for different airline allowances by weighing and adjusting bags ahead of international or domestic departures.</p>
           
-          <a class="post-card__cta" href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/international-vs-domestic-trips-planning-for-weight-differences/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -304,7 +314,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -327,7 +337,9 @@
           
           <p class="post-card__excerpt">Run a two-minute weigh-in circuit for every suitcase so the whole family clears airline scales without drama.</p>
           
-          <a class="post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -336,7 +348,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -359,7 +371,9 @@
           
           <p class="post-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
           
-          <a class="post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -368,7 +382,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -391,7 +405,9 @@
           
           <p class="post-card__excerpt">Use smart packing moves and mid-pack weigh-ins to keep every checked suitcase comfortably under 50 pounds.</p>
           
-          <a class="post-card__cta" href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -400,7 +416,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -423,7 +439,9 @@
           
           <p class="post-card__excerpt">Understand carry-on weight rules and use quick luggage scale checks so gate agents never flag your bag.</p>
           
-          <a class="post-card__cta" href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>
@@ -432,7 +450,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -455,7 +473,9 @@
           
           <p class="post-card__excerpt">Master the shake-to-charge routine so your battery-free luggage scale delivers dependable readings on every trip.</p>
           
-          <a class="post-card__cta" href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -144,7 +144,7 @@
     
     
     
-    <li>
+    <li class="post-grid__item">
       <article class="post-card">
         
         <div class="post-card__body">
@@ -167,7 +167,9 @@
           
           <p class="post-card__excerpt">Step-by-step plan to weigh your suitcases ahead of travel so you skip surprise overweight fees.</p>
           
-          <a class="post-card__cta" href="/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Read the article →</a>
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">Read the article</a>
+          </div>
         </div>
       </article>
     </li>

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1,145 +1,296 @@
-@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
 
-/* Blog design tokens */
 :root {
-  color-scheme: dark;
-  --font-sans: "Plus Jakarta Sans", "InterVariable", "Inter var", "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  --font-mono: "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  --color-bg: #071427;
-  --color-surface: #122746;
-  --color-surface-soft: #18335c;
-  --color-surface-elevated: rgba(21, 44, 78, 0.82);
-  --color-text: #f3f8ff;
-  --color-muted: #c9d7f2;
-  --color-subtle: #8aa3c3;
-  --color-border: rgba(112, 158, 214, 0.28);
-  --color-border-strong: rgba(112, 158, 214, 0.45);
-  --color-accent: #4db8ff;
-  --color-accent-secondary: #53dcc6;
-  --color-accent-soft: rgba(83, 220, 198, 0.2);
-  --shadow-xs: 0 10px 24px rgba(3, 12, 26, 0.35);
-  --shadow-sm: 0 32px 70px rgba(5, 18, 37, 0.55);
-  --radius-sm: 0.65rem;
-  --radius-md: 0.95rem;
-  --max-reading-width: 72ch;
-  --toc-width: 19rem;
-  --gradient-divider: linear-gradient(90deg, rgba(83, 220, 198, 0.4) 0%, rgba(77, 184, 255, 0.35) 100%);
-  --gradient-quote: linear-gradient(135deg, rgba(83, 220, 198, 0.22), rgba(77, 184, 255, 0.16));
-  --space-0: 0;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2rem;
-  --space-7: 3rem;
-  --space-8: 4rem;
-  --space-9: 5rem;
+  --color-blue: #002f5f;
+  --color-red: #c62828;
+  --color-white: #ffffff;
+  --color-body: #333333;
+  --color-muted: #6b7280;
+  --color-border: rgba(0, 47, 95, 0.18);
+  --color-border-strong: rgba(0, 47, 95, 0.28);
+  --shadow-card: 0 18px 34px rgba(0, 47, 95, 0.14);
+  --shadow-soft: 0 10px 20px rgba(0, 47, 95, 0.1);
+  --radius-card: 1rem;
+  --radius-pill: 999px;
+  --max-site-width: 72rem;
+  --max-content-width: 44rem;
+  --transition-fast: 180ms ease;
 }
 
-/* Base layout */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 100%;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: var(--font-sans);
-  font-size: clamp(1.05rem, 1rem + 0.25vw, 1.1rem);
-  line-height: 1.7;
-  background: radial-gradient(120% 120% at 50% 0%, rgba(24, 52, 96, 0.45), transparent 55%), var(--color-bg);
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  -webkit-font-smoothing: antialiased;
+  font-family: "Inter", "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--color-body);
+  background-color: var(--color-white);
   text-rendering: optimizeLegibility;
-  font-feature-settings: "liga" 1, "kern" 1;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  display: block;
+}
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: calc(var(--radius-card) - 0.25rem);
+}
+
+figure {
+  margin: 0 0 1.5rem;
+}
+
+figcaption {
+  margin-top: 0.75rem;
+  font-size: 0.9375rem;
+  color: var(--color-muted);
+}
+
+p,
+ul,
+ol,
+blockquote,
+pre,
+table {
+  margin: 0 0 1.5rem;
+}
+
+ul,
+ol {
+  padding-left: 1.4rem;
+}
+
+li + li {
+  margin-top: 0.35rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--color-blue);
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 1rem;
+}
+
+h1 {
+  font-size: clamp(2.25rem, 2rem + 1vw, 3rem);
+}
+
+h2 {
+  font-size: clamp(1.75rem, 1.5rem + 0.6vw, 2.25rem);
+}
+
+h3 {
+  font-size: clamp(1.5rem, 1.35rem + 0.4vw, 1.875rem);
+}
+
+h4 {
+  font-size: clamp(1.25rem, 1.15rem + 0.2vw, 1.5rem);
 }
 
 a {
-  color: var(--color-accent-secondary);
-  text-decoration: none;
+  color: var(--color-blue);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: rgba(0, 47, 95, 0.35);
   font-weight: 500;
-  transition: color 150ms ease, text-decoration-color 150ms ease;
+  transition: color var(--transition-fast), text-decoration-color var(--transition-fast);
 }
 
 a:hover,
 a:focus {
-  color: var(--color-accent);
-  text-decoration: underline;
-  text-decoration-color: currentColor;
+  color: var(--color-red);
+  text-decoration-color: rgba(198, 40, 40, 0.75);
 }
 
-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
-  border-radius: var(--radius-sm);
+a:focus-visible,
+button:focus-visible,
+.btn:focus-visible {
+  outline: 3px solid rgba(198, 40, 40, 0.45);
+  outline-offset: 3px;
 }
 
-.icon {
-  width: 1.1em;
-  height: 1.1em;
-  display: inline-block;
-  flex-shrink: 0;
-  color: var(--color-accent-secondary);
-  vertical-align: middle;
+code,
+pre {
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: rgba(0, 47, 95, 0.08);
+  border-radius: 0.5rem;
+  padding: 0.15rem 0.35rem;
+}
+
+pre {
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+}
+
+blockquote {
+  border-left: 0.3rem solid var(--color-red);
+  background: rgba(198, 40, 40, 0.08);
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius-card);
+  font-style: italic;
+}
+
+blockquote p {
+  margin-bottom: 0.75rem;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.pullquote {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.callout {
+  border: 2px dashed rgba(0, 47, 95, 0.25);
+  background: rgba(0, 47, 95, 0.06);
+  padding: 1.5rem;
+  border-radius: var(--radius-card);
+}
+
+hr {
+  border: none;
+  border-top: 1px solid rgba(0, 47, 95, 0.12);
+  margin: 2.5rem 0;
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  background: var(--color-white);
+  box-shadow: var(--shadow-soft);
+}
+
+thead {
+  background: rgba(0, 47, 95, 0.08);
+}
+
+thead th {
+  color: var(--color-blue);
+  font-weight: 600;
+}
+
+th,
+td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 47, 95, 0.12);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+tbody tr:nth-child(even) {
+  background: rgba(0, 47, 95, 0.03);
 }
 
 .container {
-  width: min(100%, 78rem);
+  width: 100%;
+  max-width: var(--max-site-width);
   margin: 0 auto;
-  padding-left: clamp(1.5rem, 4vw, 3.5rem);
-  padding-right: clamp(1.5rem, 4vw, 3.5rem);
+  padding: 0 1.5rem;
 }
 
 .site-header {
-  background: rgba(18, 39, 70, 0.92);
-  backdrop-filter: blur(18px);
-  padding: var(--space-5) 0 var(--space-4);
-  border-bottom: 1px solid rgba(112, 158, 214, 0.25);
-  margin-bottom: var(--space-7);
-  box-shadow: var(--shadow-xs);
-  position: relative;
-  z-index: 1;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.97);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: 0 4px 20px rgba(0, 47, 95, 0.08);
 }
 
-footer {
-  background: rgba(18, 39, 70, 0.9);
-  padding: var(--space-6) 0;
-  border-top: 1px solid rgba(112, 158, 214, 0.2);
-  margin-top: var(--space-8);
-  font-size: 0.95rem;
-  color: var(--color-subtle);
-  box-shadow: var(--shadow-xs);
-}
-
-main {
-  padding: var(--space-7) 0 var(--space-8);
+.site-header .container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 }
 
 .site-header__nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .site-header__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: 1.1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-text);
+  font-size: 1.2rem;
   font-weight: 700;
+  color: var(--color-blue);
+  text-decoration: none;
 }
 
 .site-header__brand:hover,
 .site-header__brand:focus {
-  color: var(--color-accent);
+  color: var(--color-red);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  position: relative;
+  color: var(--color-blue);
+  text-decoration: none;
+  font-weight: 600;
+  padding-bottom: 0.2rem;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: transparent;
+  transition: background var(--transition-fast);
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus::after {
+  background: var(--color-red);
 }
 
 .breadcrumbs {
-  margin-top: var(--space-3);
-  font-size: 0.95rem;
-  color: var(--color-subtle);
+  font-size: 0.9375rem;
+  color: var(--color-muted);
 }
 
 .breadcrumbs__list {
@@ -148,643 +299,277 @@ main {
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.breadcrumbs__item {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.breadcrumbs__item:not(:last-child)::after {
-  content: "›";
-  opacity: 0.5;
-  color: var(--color-subtle);
-  font-size: 1rem;
+  gap: 0.5rem;
 }
 
 .breadcrumbs__item a {
-  color: var(--color-accent-secondary);
-  font-weight: 500;
-}
-
-.breadcrumbs__item span[aria-current="page"] {
+  text-decoration: none;
   color: var(--color-muted);
-  font-weight: 500;
 }
 
-@media (max-width: 768px) {
-  .container {
-    padding-left: clamp(1.25rem, 6vw, 2rem);
-    padding-right: clamp(1.25rem, 6vw, 2rem);
-  }
-
-  .site-header {
-    margin-bottom: var(--space-6);
-  }
-
-  main {
-    padding: var(--space-6) 0 var(--space-7);
-  }
+.breadcrumbs__item a:hover,
+.breadcrumbs__item a:focus {
+  color: var(--color-red);
+  text-decoration: underline;
 }
 
-@media (max-width: 520px) {
-  .breadcrumbs {
-    font-size: 0.9rem;
-  }
+.site-main {
+  padding: 4rem 0 5rem;
 }
 
-@media (min-width: 1200px) {
-  .container {
-    width: min(100%, 84rem);
-    padding-left: clamp(2.5rem, 6vw, 4.5rem);
-    padding-right: clamp(2.5rem, 6vw, 4.5rem);
-  }
+main.container {
+  padding-top: 4rem;
+  padding-bottom: 5rem;
 }
 
-/* Typography */
-h1,
-h2,
-h3,
-h4 {
-  margin: 0 0 var(--space-3);
+.page-intro {
+  max-width: 40rem;
+  display: grid;
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.page-lede {
+  font-size: 1.05rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.btn-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+  padding: 0.65rem 1.1rem;
   line-height: 1.2;
-  color: var(--color-text);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  text-decoration: none;
+  box-sizing: border-box;
+  min-height: 2.75rem;
 }
 
-h1,
-.heading-xl {
-  font-size: clamp(2.5rem, 5vw, 3.35rem);
-  font-weight: 750;
+.btn:active {
+  transform: translateY(1px);
 }
 
-h2,
-.heading-lg {
-  font-size: clamp(1.95rem, 3.5vw, 2.5rem);
-  font-weight: 650;
+.btn.solid {
+  background: var(--color-blue);
+  color: var(--color-white);
+  border-color: var(--color-blue);
 }
 
-h3,
-.heading-md {
-  font-size: clamp(1.45rem, 2.8vw, 1.95rem);
-  font-weight: 600;
-  color: var(--color-muted);
+.btn.solid:hover,
+.btn.solid:focus {
+  background: var(--color-red);
+  border-color: var(--color-red);
 }
 
-h4,
-.heading-sm {
-  font-size: 1.2rem;
-  font-weight: 600;
+.btn.outline {
+  background: var(--color-white);
+  color: var(--color-blue);
+  border-color: var(--color-blue);
 }
 
-p {
-  margin: 0 0 var(--space-4);
+.btn.outline:hover,
+.btn.outline:focus {
+  background: var(--color-red);
+  color: var(--color-white);
+  border-color: var(--color-red);
 }
 
-strong {
-  font-weight: 650;
+.section-title {
+  margin-bottom: 1.5rem;
 }
 
-code,
-pre {
-  font-family: var(--font-mono);
-  background-color: rgba(12, 30, 54, 0.65);
-  color: var(--color-text);
-}
-
-code {
-  padding: 0.15em 0.45em;
-  border-radius: 0.45rem;
-  border: 1px solid var(--color-border);
-}
-
-pre {
-  overflow-x: auto;
-  padding: var(--space-3);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-}
-
-pre code {
-  background: transparent;
-  border: 0;
-  padding: 0;
-}
-
-hr {
-  border: none;
-  height: 1px;
-  background: var(--gradient-divider);
-  border-radius: 999px;
-  margin: var(--space-7) 0;
-  position: relative;
-  overflow: visible;
-}
-
-hr::after {
-  content: "";
-  position: absolute;
-  right: 0;
-  top: -0.5rem;
-  width: 5rem;
-  height: 1rem;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22120%22%20height%3D%2210%22%20fill%3D%22none%22%20viewBox%3D%220%200%20120%2010%22%3E%3Cpath%20d%3D%22M0%206C15%202%2030%202%2045%206C60%209%2075%209%2090%206C105%203%20110%202%20120%205%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.45%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-size: contain;
-  opacity: 0.7;
-}
-
-blockquote {
-  margin: var(--space-7) 0;
-  padding: var(--space-4) var(--space-5);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border-strong);
-  background: var(--gradient-quote);
-  color: var(--color-text);
-  position: relative;
-  overflow: hidden;
-}
-
-blockquote::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.12), transparent 60%);
-  pointer-events: none;
-}
-
-blockquote p:last-child {
-  margin-bottom: 0;
-}
-
-/* Utility spacing helpers */
-.stack-xs > * + * {
-  margin-top: var(--space-2);
-}
-
-.stack-sm > * + * {
-  margin-top: var(--space-3);
-}
-
-.stack-md > * + * {
-  margin-top: var(--space-4);
-}
-
-.stack-lg > * + * {
-  margin-top: var(--space-6);
-}
-
-.text-muted {
-  color: var(--color-muted);
-}
-
-/* Blog listing */
-.blog-index__title {
-  margin: 0 0 var(--space-2);
-  color: var(--color-text);
-}
-
-.blog-index__intro {
-  margin: 0 0 var(--space-6);
-  max-width: 60ch;
-  color: var(--color-subtle);
+.post-feed {
+  display: grid;
+  gap: 2.5rem;
 }
 
 .post-grid {
+  display: grid;
+  gap: 1.75rem;
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: clamp(var(--space-5), 3vw, var(--space-6));
-  grid-template-columns: 1fr;
 }
 
-.post-grid > li {
-  margin: 0;
-}
-
-@media (min-width: 40rem) {
-  .post-grid {
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
-  }
+.post-grid__item {
+  display: flex;
 }
 
 .post-card {
-  background: linear-gradient(135deg, rgba(26, 53, 95, 0.9), rgba(18, 39, 70, 0.95));
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-5), 2vw + 1.25rem, var(--space-6));
-  display: grid;
-  gap: var(--space-5);
-  height: 100%;
-  color: var(--color-text);
-  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+  background: var(--color-white);
+  border-radius: var(--radius-card);
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  width: 100%;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .post-card:hover,
 .post-card:focus-within {
-  transform: translateY(-2px);
-  border-color: rgba(83, 220, 198, 0.45);
-  box-shadow: 0 36px 70px rgba(5, 18, 37, 0.6);
-}
-
-.post-card--with-image {
-  align-items: center;
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-card);
 }
 
 .post-card__media {
   display: block;
-  border-radius: calc(var(--radius-md) - var(--space-1));
   overflow: hidden;
-  aspect-ratio: 16 / 9;
-  background-color: rgba(77, 184, 255, 0.12);
 }
 
 .post-card__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  aspect-ratio: 16 / 9;
+  border-radius: 0;
 }
 
 .post-card__body {
-  display: grid;
-  gap: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.75rem;
 }
 
 .post-card__title {
   margin: 0;
-  font-size: clamp(1.65rem, 2.4vw, 2.1rem);
-  line-height: 1.25;
-  font-weight: 700;
+  font-size: 1.45rem;
 }
 
 .post-card__title a {
-  color: inherit;
+  text-decoration: none;
+}
+
+.post-card__title a:hover,
+.post-card__title a:focus {
+  color: var(--color-red);
 }
 
 .post-meta {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: 0.85rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-subtle);
-}
-
-.post-meta__author,
-.post-meta__date {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
+  gap: 0.35rem 0.6rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  margin: 0;
 }
 
 .post-meta__separator {
-  color: var(--color-subtle);
+  color: rgba(0, 47, 95, 0.35);
 }
 
 .post-card__excerpt {
   margin: 0;
-  color: var(--color-muted);
-}
-
-.post-card__cta {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 600;
-  color: var(--color-accent);
-}
-
-.post-card__cta:hover,
-.post-card__cta:focus {
-  text-decoration: underline;
-}
-
-.post-card__cta-icon {
-  transition: transform 150ms ease;
-}
-
-.post-card__cta:hover .post-card__cta-icon,
-.post-card__cta:focus .post-card__cta-icon {
-  transform: translateX(0.2rem);
-}
-
-@media (min-width: 768px) {
-  .post-card--with-image {
-    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.45fr);
-  }
-}
-
-@media (max-width: 600px) {
-  .post-card {
-    padding: var(--space-5);
-  }
-
-  .post-card--with-image {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-/* Pagination */
-.pagination {
-  margin-top: var(--space-7);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: var(--color-muted);
-}
-
-.pagination__link {
-  color: var(--color-accent-secondary);
-  font-weight: 600;
-}
-
-.pagination__link--prev {
-  margin-right: auto;
-}
-
-.pagination__link--next {
-  margin-left: auto;
-}
-
-/* Post layout */
-.post {
-  background: linear-gradient(135deg, rgba(20, 45, 80, 0.95), rgba(15, 34, 64, 0.92));
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-  padding: clamp(var(--space-6), 4vw + 1.25rem, var(--space-9));
-  display: grid;
-  gap: var(--space-6);
-  color: var(--color-text);
-  position: relative;
+  color: var(--color-body);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
   overflow: hidden;
 }
 
+.post-card__actions {
+  margin-top: auto;
+}
+
+.post-card__cta {
+  align-self: flex-start;
+}
+
+.blog-list__empty {
+  padding: 2rem;
+  border-radius: var(--radius-card);
+  border: 1px dashed rgba(0, 47, 95, 0.3);
+  text-align: center;
+  background: rgba(0, 47, 95, 0.05);
+}
+
+.post {
+  background: var(--color-white);
+  border-radius: var(--radius-card);
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.75rem, 1.5rem + 1vw, 3rem);
+  max-width: calc(var(--max-content-width) + 20rem);
+  margin: 0 auto;
+}
+
 .post__header {
-  display: grid;
-  gap: var(--space-4);
-  position: relative;
-  padding-bottom: var(--space-2);
-}
-
-.post__header::before {
-  content: "";
-  position: absolute;
-  inset: -30% -10% auto -10%;
-  height: 140%;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22220%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20220%22%3E%3Cpath%20d%3D%22M-20%20160C80%20120%20160%20200%20260%20160C340%20130%20380%20150%20460%20120%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.25%22/%3E%3Cpath%20d%3D%22M-10%20120C90%2080%20180%20140%20280%20110C360%2090%20420%20110%20500%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-size: cover;
-  opacity: 0.25;
-  pointer-events: none;
-}
-
-.post__header > * {
-  position: relative;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(0, 47, 95, 0.12);
+  margin-bottom: 2rem;
 }
 
 .post__title {
-  margin: 0;
-  font-weight: 760;
-  line-height: 1.2;
+  margin-bottom: 0.75rem;
 }
 
 .post__excerpt {
   margin: 0;
   color: var(--color-muted);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 
 .post__content-grid {
-  display: grid;
-  gap: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
 .post__content-column {
-  display: grid;
-  gap: var(--space-6);
-  align-content: start;
-}
-
-.post__body {
-  display: grid;
-  gap: var(--space-5);
-  font-size: 1.05rem;
-  line-height: 1.7;
-  max-width: var(--max-reading-width);
+  max-width: var(--max-content-width);
   width: 100%;
-  margin: 0 auto;
-  color: var(--color-text);
 }
 
 .post__body > * {
-  margin: 0;
+  margin-top: 0;
 }
 
-.post__body h2 {
-  margin-top: var(--space-7);
-  padding-bottom: var(--space-2);
-  border-bottom: 1px solid rgba(83, 220, 198, 0.18);
-  position: relative;
-}
-
-.post__body h2::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -1px;
-  width: 3.5rem;
-  height: 3px;
-  background: var(--gradient-divider);
-  border-radius: 999px;
-}
-
-.post__body h2:first-of-type {
-  margin-top: var(--space-4);
-}
-
-.post__body h3 {
-  margin-top: var(--space-5);
-  padding-left: var(--space-3);
-  color: var(--color-subtle);
-  position: relative;
-  font-weight: 600;
-}
-
-.post__body h3::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.65rem;
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.8), rgba(83, 220, 198, 0.6));
-  box-shadow: 0 0 0 4px rgba(77, 184, 255, 0.12);
+.post__body > * + * {
+  margin-top: 1.75rem;
 }
 
 .post__body h2,
-.post__body h3 {
-  scroll-margin-top: clamp(6rem, 7vw, 8rem);
-}
-
-.post__body a {
-  color: var(--color-accent-secondary);
-  text-decoration: underline;
-  text-decoration-color: rgba(83, 220, 198, 0.45);
-  font-weight: 500;
-}
-
-.post__body a:hover,
-.post__body a:focus {
-  color: var(--color-accent);
-  text-decoration-color: rgba(77, 184, 255, 0.55);
+.post__body h3,
+.post__body h4 {
+  margin-top: 2.5rem;
 }
 
 .post__body ul,
 .post__body ol {
-  list-style: none;
-  margin: 0 0 var(--space-5);
-  padding: 0;
-  display: grid;
-  gap: var(--space-3);
-}
-
-.post__body li {
-  position: relative;
-  padding: calc(var(--space-3) + 0.15rem) var(--space-4) calc(var(--space-3) + 0.15rem) calc(var(--space-4) + 2.1rem);
-  background: rgba(15, 32, 58, 0.35);
-  border: 1px solid rgba(112, 158, 214, 0.24);
-  border-radius: var(--radius-sm);
-  line-height: 1.65;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  transition: border-color 150ms ease, transform 150ms ease;
-}
-
-.post__body li:hover {
-  border-color: rgba(83, 220, 198, 0.35);
-  transform: translateY(-1px);
-}
-
-.post__body li strong {
-  color: var(--color-text);
-}
-
-.post__body li p:last-child {
-  margin-bottom: 0;
-}
-
-.post__body ul li::before {
-  content: "";
-  position: absolute;
-  left: var(--space-3);
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 1.6rem;
-  height: 1.6rem;
-  border-radius: 999px;
-  background:
-    radial-gradient(circle at 50% 50%, rgba(83, 220, 198, 0.25), transparent 70%),
-    url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%2214%22%20height%3D%2212%22%20fill%3D%22none%22%20viewBox%3D%220%200%2014%2012%22%3E%3Cpath%20d%3D%22M1.5%206.5L4.8%209.5L12.5%201.5%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22/%3E%3C/svg%3E") center/0.85rem 0.85rem no-repeat;
-}
-
-.post__body ol {
-  counter-reset: step;
-}
-
-.post__body ol li {
-  counter-increment: step;
-}
-
-.post__body ol li::before {
-  content: counter(step);
-  position: absolute;
-  left: var(--space-3);
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 1.95rem;
-  height: 1.95rem;
-  border-radius: 50%;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.45), rgba(83, 220, 198, 0.45));
-  color: var(--color-text);
-  font-weight: 600;
-  font-size: 0.9rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 6px 12px rgba(5, 18, 37, 0.3);
-  font-variant-numeric: tabular-nums;
-}
-
-.post__body hr {
-  margin: var(--space-7) auto;
-}
-
-.post__body blockquote {
-  margin: var(--space-7) 0;
-}
-
-.post__disclaimer {
-  margin: var(--space-7) auto 0;
-  padding: var(--space-4) var(--space-5);
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(83, 220, 198, 0.28);
-  background: var(--color-surface-elevated);
-  color: var(--color-muted);
-  font-size: 0.95rem;
-  max-width: var(--max-reading-width);
-  width: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.post__disclaimer::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%20width%3D%22480%22%20height%3D%22160%22%20fill%3D%22none%22%20viewBox%3D%220%200%20480%20160%22%3E%3Cpath%20d%3D%22M-40%20120C40%2090%20140%20140%20220%20110C300%2080%20340%20100%20440%2080%22%20stroke%3D%22%2353dcc6%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.2%22/%3E%3Cpath%20d%3D%22M-10%2090C70%2060%20140%2090%20240%2070C320%2060%20390%2080%20480%2060%22%20stroke%3D%22%234db8ff%22%20stroke-width%3D%221.4%22%20stroke-linecap%3D%22round%22%20stroke-opacity%3D%220.22%22/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-size: cover;
-  opacity: 0.35;
-  pointer-events: none;
-}
-
-.post__disclaimer > * {
-  position: relative;
-  margin: 0;
+  padding-left: 1.5rem;
 }
 
 .post__toc {
-  display: none;
+  position: static;
 }
 
 .post__toc-inner {
-  position: sticky;
-  top: clamp(5.5rem, 8vw, 7rem);
-  background: rgba(18, 39, 70, 0.85);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  box-shadow: var(--shadow-xs);
-  backdrop-filter: blur(12px);
-  display: grid;
-  gap: var(--space-3);
+  background: rgba(0, 47, 95, 0.03);
+  border-radius: var(--radius-card);
+  padding: 1.5rem;
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  box-shadow: var(--shadow-soft);
 }
 
 .post__toc-title {
-  margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-subtle);
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
 }
 
 .post__toc-list {
@@ -792,120 +577,140 @@ blockquote p:last-child {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: var(--space-2);
+  gap: 0.65rem;
 }
 
 .post__toc-item--level-3 {
-  padding-left: var(--space-2);
+  padding-left: 1rem;
 }
 
 .post__toc-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--color-muted);
-  padding: 0.35rem 0;
-  border-left: 2px solid transparent;
-  transition: color 150ms ease, border-color 150ms ease;
   text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.post__toc-link::before {
-  content: "";
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 999px;
-  background: linear-gradient(135deg, rgba(77, 184, 255, 0.9), rgba(83, 220, 198, 0.7));
-  opacity: 0.6;
-}
-
-.post__toc-item--level-3 .post__toc-link {
-  font-size: 0.9rem;
-  color: rgba(201, 215, 242, 0.8);
-}
-
-.post__toc-item--level-3 .post__toc-link::before {
-  width: 0.35rem;
-  height: 0.35rem;
-  opacity: 0.5;
+  color: var(--color-blue);
+  font-weight: 500;
 }
 
 .post__toc-link:hover,
 .post__toc-link:focus {
-  color: var(--color-accent);
-  border-color: rgba(77, 184, 255, 0.45);
+  color: var(--color-red);
+  text-decoration: underline;
 }
 
-.post__toc-link:focus-visible {
-  outline: 2px solid rgba(83, 220, 198, 0.5);
-  outline-offset: 2px;
+.post__disclaimer {
+  margin-top: 2.5rem;
+  padding: 1.25rem 1.5rem;
+  background: rgba(0, 47, 95, 0.05);
+  border-radius: var(--radius-card);
+  border: 1px solid rgba(0, 47, 95, 0.12);
+  font-size: 0.95rem;
 }
 
-@media (min-width: 960px) {
-  .post__content-grid {
-    grid-template-columns: minmax(0, 1fr) minmax(0, var(--toc-width));
-    align-items: start;
-    gap: var(--space-7);
+.pagination {
+  margin-top: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.pagination__info {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.site-footer,
+footer {
+  background: var(--color-blue);
+  color: var(--color-white);
+  padding: 2.5rem 0;
+  margin-top: 4rem;
+}
+
+.site-footer a,
+footer a {
+  color: var(--color-white);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.site-footer a:hover,
+.site-footer a:focus,
+footer a:hover,
+footer a:focus {
+  color: var(--color-red);
+}
+
+.post-page .site-main {
+  padding-top: 3.5rem;
+}
+
+.post-page main.container {
+  padding-top: 3.5rem;
+}
+
+@media (min-width: 480px) {
+  .page-intro {
+    margin-bottom: 3.5rem;
+  }
+}
+
+@media (min-width: 640px) {
+  .post-grid {
+    grid-template-columns: repeat(auto-fit, minmax(18.5rem, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  body {
+    font-size: 1.0625rem;
   }
 
-  .post__toc {
-    display: block;
+  .site-main {
+    padding: 4.5rem 0 5.5rem;
+  }
+
+  .page-intro {
+    gap: 1.5rem;
   }
 }
 
 @media (min-width: 900px) {
-  .post__body ol {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-4);
-  }
-}
-
-@media (max-width: 960px) {
-  .post__content-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 720px) {
-  .post__body ul,
-  .post__body ol {
-    gap: var(--space-2);
-  }
-}
-
-@media (max-width: 600px) {
-  .post {
-    padding: clamp(var(--space-5), 4vw + 1rem, var(--space-7));
-  }
-
-  .post__body li {
-    padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 1.8rem);
-  }
-
-  .post__body ul li::before,
-  .post__body ol li::before {
-    left: var(--space-3);
-  }
-}
-
-/* Footer */
-footer .container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-footer a {
-  color: var(--color-accent-secondary);
-}
-
-@media (max-width: 640px) {
-  footer .container {
+  .site-header .container {
     flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-2);
+    align-items: stretch;
+  }
+
+  .post {
+    padding: clamp(2.5rem, 2rem + 1vw, 3.5rem);
+  }
+
+  .post__content-grid {
+    display: grid;
+    grid-template-columns: minmax(0, var(--max-content-width)) minmax(16rem, 20rem);
+    gap: 3rem;
+    align-items: start;
+  }
+
+  .post__toc {
+    position: sticky;
+    top: 7.5rem;
+  }
+}
+
+@media (min-width: 1100px) {
+  .site-header .container {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the blog with an Inter-based blue/red/white system, responsive typography, card layouts, and unified button patterns
- refresh the blog index template with a hero intro, navigation links, and styled pagination controls that consume the new components
- update the shared blog list partial to render card previews with consistent metadata, excerpts, and CTA buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15eea404c8332932caf5a530a62c0