### PR TITLE
Remove node-fetch import from generate-posts script

### DIFF
--- a/scripts/generate-posts.js
+++ b/scripts/generate-posts.js
@@ -16,7 +16,6 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import fetch from "node-fetch";
 
 // --- Constants ---
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary
- remove the node-fetch import from the blog post generation script so it uses Node 20's global fetch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1efde8cd8833282c0911111757def