### PR TITLE
Handle missing section content in word count checks

### DIFF
--- a/scripts/generate-posts.js
+++ b/scripts/generate-posts.js
@@ -57,7 +57,10 @@ function slugify(str) {
 }
 
 function countWords(str) {
-  return str.trim().split(/\s+/).filter(Boolean).length;
+  if (typeof str !== "string") return 0;
+  const trimmed = str.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).filter(Boolean).length;
 }
 
 // --- Fake OpenAI Call (placeholder) ---
@@ -69,6 +72,12 @@ async function callOpenAI(prompt, sectionName) {
 
 // --- Validation (now warnings only) ---
 function checkWordCount(sectionName, text) {
+  if (typeof text !== "string" || text.trim() === "") {
+    console.warn(
+      `⚠️ Warning: ${sectionName} has no content; skipping word count.`
+    );
+    return 0;
+  }
   const words = countWords(text);
   const [min, max] = DEFAULT_WORD_RANGES[sectionName] || [0, Infinity];
   if (words < min || words > max) {


### PR DESCRIPTION
## Summary
- guard `countWords` against non-string inputs
- skip word-count validation for empty or invalid section content while logging a warning

## Testing
- node scripts/generate-posts.js --mode=api

------
https://chatgpt.com/codex/tasks/task_e_68d1fb8573c883328ddff3a91cb378fe