### PR TITLE
Convert generate-posts script to CommonJS

### DIFF
--- a/scripts/generate-posts.js
+++ b/scripts/generate-posts.js
@@ -13,13 +13,10 @@
  * so the workflow won’t abort if a section is too short or too long.
  */
 
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+const fs = require("fs");
+const path = require("path");
 
 // --- Constants ---
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const KEYWORDS_FILE = path.join(__dirname, "keywords.txt");
 const STATE_FILE = path.join(__dirname, "../data/automation-state.json");


### PR DESCRIPTION
## Summary
- switch `scripts/generate-posts.js` from ESM imports to CommonJS `require` calls
- rely on Node's built-in `__dirname` for path resolution without using `fileURLToPath`

## Testing
- `node scripts/generate-posts.js --mode=manual`


------
https://chatgpt.com/codex/tasks/task_e_68d1fd983af8833298491916bad19b81