### PR TITLE
Ensure state directory exists before saving automation state

### DIFF
--- a/scripts/generate-posts.js
+++ b/scripts/generate-posts.js
@@ -46,6 +46,7 @@ function loadState() {
 }
 
 function saveState(state) {
+  fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
   fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
 }
 


### PR DESCRIPTION
## Summary
- ensure `saveState` creates the automation data directory before writing the state file

## Testing
- node scripts/generate-posts.js --mode=api

------
https://chatgpt.com/codex/tasks/task_e_68d200e3ab2c833289c30fe1b84ffb7c