### PR TITLE
Fix meta placement in flight baggage limits page

### DIFF
--- a/flight-baggage-limits.html
+++ b/flight-baggage-limits.html
@@ -2,15 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Flight Weight Limit— uPatch Luggage Scale</title>
+  <title>Flight Baggage Limits — uPatch Luggage Scale</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Favicon + tab color -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2">
   <meta name="theme-color" content="#0a1a2f">
-<body>
- <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Flight Baggage Limits</title>
   <style>
     body {
       font-family: 'Segoe UI', sans-serif;
@@ -104,6 +100,8 @@
   }
 </style>
 </head>
+
+<body>
 
 <!-- PASTE this block directly ABOVE your <h1>🌏 Flight Baggage Limits</h1> -->
 <nav class="nav-tiles" role="navigation" aria-label="Top pages">
@@ -584,4 +582,6 @@
 
 
 </body>
+
+</html>
 


### PR DESCRIPTION
## Summary
- keep the meta and title tags inside the head element and remove duplicates
- ensure the body opens after the head closes and add the missing closing html tag

## Testing
- ✅ Viewed flight-baggage-limits.html in a local browser session via Playwright screenshot
- ⚠️ `npx --yes htmlhint@latest flight-baggage-limits.html` *(fails with npm 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d200ee3db483328872f44474c522f9