### PR TITLE
Revamp blog post accordion layout and footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 .DS_Store
+node_modules/

--- a/blog-src/_data/config.json
+++ b/blog-src/_data/config.json
@@ -28,6 +28,14 @@
       "clientId": "ca-pub-1234567890123456"
     }
   },
+  "legal": {
+    "links": [
+      { "label": "Privacy Policy", "url": "https://luggage-scale.com/privacy" },
+      { "label": "Terms of Service", "url": "https://luggage-scale.com/terms" },
+      { "label": "Affiliate Disclosure", "url": "https://luggage-scale.com/affiliate-disclosure" },
+      { "label": "Contact", "url": "https://luggage-scale.com/contact" }
+    ]
+  },
   "affiliate": {
     "amazon": {
       "tag": "luggagescale-20",

--- a/blog-src/_includes/layouts/post.njk
+++ b/blog-src/_includes/layouts/post.njk
@@ -68,14 +68,13 @@
   ] %}
   {% set prepared = content | preparePostContent(title) %}
   {% from "icons.njk" import icon %}
-  {% from "macros/post-macros.njk" import renderToc, renderAffiliate %}
+  {% from "macros/post-macros.njk" import renderAffiliate %}
   {% set hasSections = prepared.sections and (prepared.sections | length) %}
   {% if hasSections %}
-    {% set tocSections = prepared.sections %}
+    {% set accordionSections = prepared.sections %}
   {% else %}
-    {% set tocSections = [] %}
+    {% set accordionSections = [] %}
   {% endif %}
-  {% set hasToc = tocSections and (tocSections | length) %}
   {% set affiliateAmazon = config.affiliate.amazon or {} %}
   {% set affiliateProducts = affiliateAmazon.products or {} %}
   {% set affiliateProductKey = affiliateProduct %}
@@ -107,11 +106,15 @@
   {% endif %}
   {% set showFooterDisclaimer = affiliateDisclaimer and not (affiliateCard and affiliateCard.disclaimer == affiliateDisclaimer) %}
   {% set rootUrl = config.site.url or config.site.base or '/' %}
-  {% set legalLinks = [
-    { "label": "Privacy", "url": rootUrl ~ "/privacy" },
-    { "label": "Terms", "url": rootUrl ~ "/terms" },
-    { "label": "Contact", "url": rootUrl ~ "/contact" }
-  ] %}
+  {% set legalLinks = config.legal.links or [] %}
+  {% if not legalLinks or not (legalLinks | length) %}
+    {% set legalLinks = [
+      { "label": "Privacy Policy", "url": rootUrl ~ "/privacy" },
+      { "label": "Terms of Service", "url": rootUrl ~ "/terms" },
+      { "label": "Affiliate Disclosure", "url": rootUrl ~ "/affiliate-disclosure" },
+      { "label": "Contact", "url": rootUrl ~ "/contact" }
+    ] %}
+  {% endif %}
   {% set breadcrumbStructuredData = breadcrumbTrail | breadcrumbJsonLd(site, canonicalHref) %}
   {% set publisherLogo = site.logoPath %}
   {% if publisherLogo %}
@@ -202,110 +205,71 @@
         {% endif %}
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
-          {% if hasToc %}
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">{{ icon('toc') }}</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">{{ icon('chevron-down') }}</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                {{ renderToc(tocSections, 'mobile') | safe }}
-              </nav>
-            </div>
+      <div class="post__content">
+        {% if hasSections %}
+          {% if prepared.introHtml %}
+          <div class="post__intro">
+            {{ prepared.introHtml | safe }}
           </div>
           {% endif %}
-
-          <div class="post__body">
-            {% if hasSections %}
-            {% if prepared.introHtml %}
-            <div class="post__intro">
-              {{ prepared.introHtml | safe }}
-            </div>
+          <div class="post__sections" data-accordion>
+            {% for section in accordionSections %}
+            {% set headingKey = section.headingText | lower %}
+            {% set accent = 'brand' %}
+            {% if headingKey and headingKey.indexOf('how it works') > -1 %}
+              {% set accent = 'teal' %}
+            {% elseif headingKey and (headingKey.indexOf('key benefit') > -1 or headingKey.indexOf('benefit') > -1) %}
+              {% set accent = 'green' %}
+            {% elseif headingKey and (headingKey.indexOf('comparison') > -1 or headingKey.indexOf('compare') > -1) %}
+              {% set accent = 'orange' %}
+            {% elseif headingKey and (headingKey.indexOf('use case') > -1 or headingKey.indexOf('use-case') > -1 or headingKey.indexOf('use cases') > -1) %}
+              {% set accent = 'purple' %}
+            {% elseif headingKey and headingKey.indexOf('why it matters') > -1 %}
+              {% set accent = 'brand' %}
             {% endif %}
-
-            {% for section in tocSections %}
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="{{ section.id }}">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-{{ section.id }}" data-section-toggle data-section="{{ section.id }}">
+            <section class="post-section" data-post-section data-accent="{{ accent }}">
+              <h2 class="post-section__heading" id="{{ section.id }}" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-{{ section.id }}" type="button" aria-expanded="true" aria-controls="section-content-{{ section.id }}" data-accordion-trigger data-section="{{ section.id }}">
                   <span class="post-section__icon" aria-hidden="true">{{ icon(section.icon, 'post-section__icon-svg') }}</span>
                   <span class="post-section__label">{{ section.headingHtml | safe }}</span>
                   <span class="post-section__chevron" aria-hidden="true">{{ icon('chevron-down') }}</span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-{{ section.id }}" data-collapsible>
-                {{ section.contentHtml | safe }}
+              <div class="post-section__panel" id="section-content-{{ section.id }}" role="region" aria-labelledby="section-trigger-{{ section.id }}" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  {{ section.contentHtml | safe }}
+                </div>
               </div>
             </section>
             {% if loop.first %}
               {{ renderAffiliate(affiliateCard) | safe }}
             {% endif %}
             {% endfor %}
-            {% else %}
-            <div class="post__body-content">
-              {{ prepared.html | safe }}
-            </div>
-            {{ renderAffiliate(affiliateCard) | safe }}
-            {% endif %}
           </div>
-
-          {% if showFooterDisclaimer %}
-          <aside class="post__disclaimer">
-            {{ affiliateDisclaimer }}
-          </aside>
-          {% endif %}
-        </div>
-
-        {% if hasToc %}
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">{{ icon('toc') }}</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              {{ renderToc(tocSections, 'desktop') | safe }}
-            </nav>
+        {% else %}
+          <div class="post__body-content">
+            {{ prepared.html | safe }}
           </div>
+          {{ renderAffiliate(affiliateCard) | safe }}
+        {% endif %}
+
+        {% if showFooterDisclaimer %}
+        <aside class="post__disclaimer">
+          {{ affiliateDisclaimer }}
         </aside>
         {% endif %}
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="{{ config.site.base }}/">{{ config.site.name }}</a>
-        <p class="site-footer__summary">{{ config.seo.defaultDescription }}</p>
-        <p class="site-footer__copyright">© {{ "now" | date("yyyy") }} {{ config.site.name }}. All rights reserved.</p>
-      </div>
-      {% if hasToc %}
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">{{ icon('toc') }}</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          {{ renderToc(tocSections, 'footer') | safe }}
-        </nav>
-      </div>
-      {% endif %}
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          {% for link in legalLinks %}
-          <li class="site-footer__link-item">
-            <a href="{{ link.url }}">{{ link.label }}</a>
-          </li>
-          {% endfor %}
-          <li class="site-footer__link-item"><a href="{{ config.site.base }}/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="{{ config.site.base }}/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© {{ "now" | date("yyyy") }} {{ config.site.name }}</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
+        {% for link in legalLinks %}
+        <a class="legal-footer__link" href="{{ link.url }}">{{ link.label }}</a>
+        {% endfor %}
+      </nav>
     </div>
   </footer>
   <script src="{{ config.site.base }}/static/post.js" defer></script>

--- a/blog-src/_includes/macros/post-macros.njk
+++ b/blog-src/_includes/macros/post-macros.njk
@@ -33,7 +33,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       {% if card.image %}
-      <img src="{{ card.image }}" alt="{{ card.imageAlt }}" loading="lazy" decoding="async">
+      <img src="{{ card.image }}" alt="{{ card.imageAlt }}" loading="lazy" decoding="async" width="160" height="160">
       {% else %}
       <div class="affiliate-card__icon">{{ icon('scale') }}</div>
       {% endif %}

--- a/blog-src/static/post.js
+++ b/blog-src/static/post.js
@@ -1,133 +1,203 @@
 (function () {
-  const sectionToggles = Array.from(document.querySelectorAll('[data-section-toggle]'));
-  const tocToggles = Array.from(document.querySelectorAll('.toc-item__toggle'));
-  const mobileTocToggle = document.querySelector('.post__toc-toggle');
-  const mobileTocPanel = document.querySelector('#post-toc-mobile');
-  const tocLinks = Array.from(document.querySelectorAll('.post__toc-nav a'));
-  const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const accordion = document.querySelector('[data-accordion]');
+  if (!accordion) return;
 
-  const prefersReducedMotion = () => reduceMotionQuery.matches;
+  const triggers = Array.from(
+    accordion.querySelectorAll('[data-accordion-trigger]')
+  );
+  if (!triggers.length) return;
 
-  const setContentHeight = (content, expanded) => {
-    if (!content) return;
-    if (prefersReducedMotion()) {
-      content.style.maxHeight = expanded ? 'none' : '0px';
-      content.dataset.open = expanded ? 'true' : 'false';
+  const reduceMotionQuery = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+  const prefersReducedMotion = () =>
+    Boolean(reduceMotionQuery && reduceMotionQuery.matches);
+
+  const getPanel = (trigger) => {
+    const controls = trigger.getAttribute('aria-controls');
+    return controls ? document.getElementById(controls) : null;
+  };
+
+  const setExpanded = (trigger, expand, options = {}) => {
+    const panel = getPanel(trigger);
+    if (!panel) return;
+
+    const { immediate = false, force = false } = options;
+    const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
+    if (!force && wasExpanded === expand) {
       return;
     }
-    if (expanded) {
-      content.dataset.open = 'true';
-      content.style.maxHeight = content.scrollHeight + 'px';
-    } else {
-      content.dataset.open = 'false';
-      content.style.maxHeight = content.scrollHeight + 'px';
+
+    trigger.setAttribute('aria-expanded', expand ? 'true' : 'false');
+    trigger.classList.toggle('is-open', expand);
+
+    panel.dataset.open = expand ? 'true' : 'false';
+    panel.setAttribute('aria-hidden', expand ? 'false' : 'true');
+
+    const skipAnimation = immediate || prefersReducedMotion();
+
+    if (skipAnimation) {
+      panel.style.transitionDuration = '0ms';
+      panel.style.maxHeight = expand ? 'none' : '0px';
+      panel.style.opacity = expand ? '1' : '0';
       requestAnimationFrame(() => {
-        content.style.maxHeight = '0px';
+        panel.style.transitionDuration = '';
+      });
+      return;
+    }
+
+    if (expand) {
+      panel.style.maxHeight = panel.scrollHeight + 'px';
+      panel.style.opacity = '1';
+      const finalize = (event) => {
+        if (event.propertyName !== 'max-height') return;
+        if (panel.dataset.open === 'true') {
+          panel.style.maxHeight = 'none';
+        }
+        panel.removeEventListener('transitionend', finalize);
+      };
+      panel.addEventListener('transitionend', finalize);
+    } else {
+      if (panel.style.maxHeight === 'none' || !panel.style.maxHeight) {
+        panel.style.maxHeight = panel.scrollHeight + 'px';
+      }
+      panel.style.opacity = '0';
+      requestAnimationFrame(() => {
+        panel.style.maxHeight = '0px';
       });
     }
   };
 
-  const toggleSection = (toggle, force) => {
-    const contentId = toggle.getAttribute('aria-controls');
-    const content = contentId ? document.getElementById(contentId) : null;
-    if (!content) return;
-    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-    const shouldExpand = typeof force === 'boolean' ? force : !isExpanded;
-    toggle.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
-    toggle.classList.toggle('is-open', shouldExpand);
-    setContentHeight(content, shouldExpand);
-  };
-
-  const updateAllSectionHeights = () => {
-    sectionToggles.forEach((toggle) => {
-      const contentId = toggle.getAttribute('aria-controls');
-      const content = contentId ? document.getElementById(contentId) : null;
-      if (!content) return;
-      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-      if (prefersReducedMotion()) {
-        content.style.maxHeight = isExpanded ? 'none' : '0px';
-      } else if (isExpanded) {
-        content.style.maxHeight = content.scrollHeight + 'px';
-      }
+  const collapseAll = (exceptTrigger, options = {}) => {
+    triggers.forEach((trigger) => {
+      if (trigger === exceptTrigger) return;
+      setExpanded(trigger, false, { ...options, force: true });
     });
   };
 
-  sectionToggles.forEach((toggle) => {
-    const contentId = toggle.getAttribute('aria-controls');
-    const content = contentId ? document.getElementById(contentId) : null;
-    if (!content) return;
-    toggle.classList.add('is-open');
-    toggle.setAttribute('aria-expanded', 'true');
-    content.dataset.open = 'true';
-    if (!prefersReducedMotion()) {
-      content.style.maxHeight = content.scrollHeight + 'px';
+  const focusTriggerAt = (index) => {
+    if (!triggers.length) return;
+    const total = triggers.length;
+    const nextIndex = (index + total) % total;
+    const target = triggers[nextIndex];
+    if (target) {
+      target.focus();
     }
-    toggle.addEventListener('click', () => toggleSection(toggle));
-  });
-
-  let resizeTimeout;
-  window.addEventListener('resize', () => {
-    clearTimeout(resizeTimeout);
-    resizeTimeout = setTimeout(updateAllSectionHeights, 150);
-  });
-
-  tocToggles.forEach((button) => {
-    const targetId = button.getAttribute('aria-controls');
-    const target = targetId ? document.getElementById(targetId) : null;
-    if (!target) return;
-    button.addEventListener('click', () => {
-      const expanded = button.getAttribute('aria-expanded') === 'true';
-      const nextState = !expanded;
-      button.setAttribute('aria-expanded', nextState ? 'true' : 'false');
-      button.classList.toggle('is-open', nextState);
-      if (nextState) {
-        target.removeAttribute('hidden');
-      } else {
-        target.setAttribute('hidden', '');
-      }
-    });
-  });
-
-  const closeMobileToc = () => {
-    if (!mobileTocToggle || !mobileTocPanel) return;
-    mobileTocToggle.setAttribute('aria-expanded', 'false');
-    mobileTocToggle.classList.remove('is-open');
-    mobileTocPanel.setAttribute('hidden', '');
   };
 
-  if (mobileTocToggle && mobileTocPanel) {
-    mobileTocToggle.addEventListener('click', () => {
-      const expanded = mobileTocToggle.getAttribute('aria-expanded') === 'true';
-      const nextState = !expanded;
-      mobileTocToggle.setAttribute('aria-expanded', nextState ? 'true' : 'false');
-      mobileTocToggle.classList.toggle('is-open', nextState);
-      if (nextState) {
-        mobileTocPanel.removeAttribute('hidden');
-      } else {
-        mobileTocPanel.setAttribute('hidden', '');
-      }
-    });
+  const openFromHash = (hash, { scroll = false, immediate = false } = {}) => {
+    if (!hash) return false;
+    const targetId = hash.replace('#', '');
+    if (!targetId) return false;
+    const trigger = triggers.find((btn) => btn.dataset.section === targetId);
+    if (!trigger) return false;
 
-    window.addEventListener('resize', () => {
-      if (window.innerWidth >= 900) {
-        closeMobileToc();
-      }
-    });
-  }
+    collapseAll(trigger, { immediate });
+    setExpanded(trigger, true, { immediate, force: true });
 
-  tocLinks.forEach((link) => {
-    link.addEventListener('click', () => {
-      const targetId = link.hash ? link.hash.slice(1) : '';
-      if (targetId) {
-        const matchingToggle = sectionToggles.find((btn) => btn.dataset.section === targetId);
-        if (matchingToggle) {
-          const isExpanded = matchingToggle.getAttribute('aria-expanded') === 'true';
-          if (!isExpanded) {
-            toggleSection(matchingToggle, true);
-          }
+    if (scroll) {
+      const heading = document.getElementById(targetId);
+      if (heading) {
+        const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+        heading.scrollIntoView({ behavior, block: 'start' });
+      }
+    }
+
+    return true;
+  };
+
+  const handleToggle = (trigger) => {
+    const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+    const nextState = !isExpanded;
+    if (nextState) {
+      collapseAll(trigger);
+    }
+    setExpanded(trigger, nextState, { force: true });
+  };
+
+  const handleKeyDown = (event) => {
+    const { key } = event;
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(key)) return;
+
+    event.preventDefault();
+    const index = triggers.indexOf(event.currentTarget);
+    if (index < 0) return;
+
+    if (key === 'ArrowDown') {
+      focusTriggerAt(index + 1);
+    } else if (key === 'ArrowUp') {
+      focusTriggerAt(index - 1);
+    } else if (key === 'Home') {
+      focusTriggerAt(0);
+    } else if (key === 'End') {
+      focusTriggerAt(triggers.length - 1);
+    }
+  };
+
+  const updateExpandedHeights = () => {
+    triggers.forEach((trigger) => {
+      const panel = getPanel(trigger);
+      if (!panel) return;
+      const expanded = trigger.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        if (prefersReducedMotion()) {
+          panel.style.maxHeight = 'none';
+        } else {
+          panel.style.maxHeight = panel.scrollHeight + 'px';
+          requestAnimationFrame(() => {
+            if (panel.dataset.open === 'true') {
+              panel.style.maxHeight = 'none';
+            }
+          });
         }
       }
-      closeMobileToc();
     });
+  };
+
+  triggers.forEach((trigger) => {
+    const panel = getPanel(trigger);
+    if (!panel) return;
+    panel.dataset.open = 'true';
+    panel.setAttribute('aria-hidden', 'false');
+
+    trigger.addEventListener('click', () => handleToggle(trigger));
+    trigger.addEventListener('keydown', handleKeyDown);
+
+    panel.addEventListener('transitionend', (event) => {
+      if (event.propertyName !== 'max-height') return;
+      if (panel.dataset.open === 'true' && !prefersReducedMotion()) {
+        panel.style.maxHeight = 'none';
+      }
+    });
+  });
+
+  window.addEventListener('resize', () => {
+    window.requestAnimationFrame(updateExpandedHeights);
+  });
+
+  const handleMotionChange = () => {
+    triggers.forEach((trigger) => {
+      const expanded = trigger.getAttribute('aria-expanded') === 'true';
+      setExpanded(trigger, expanded, { immediate: true, force: true });
+    });
+  };
+
+  if (reduceMotionQuery) {
+    if (typeof reduceMotionQuery.addEventListener === 'function') {
+      reduceMotionQuery.addEventListener('change', handleMotionChange);
+    } else if (typeof reduceMotionQuery.addListener === 'function') {
+      reduceMotionQuery.addListener(handleMotionChange);
+    }
+  }
+
+  requestAnimationFrame(() => {
+    triggers.forEach((trigger) => {
+      setExpanded(trigger, false, { immediate: true, force: true });
+    });
+    openFromHash(window.location.hash, { immediate: true, scroll: true });
+  });
+
+  window.addEventListener('hashchange', () => {
+    openFromHash(window.location.hash, { scroll: true });
   });
 })();

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -1,24 +1,33 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
 
 :root {
-  --color-base: #0f172a;
-  --color-text: #1f2937;
-  --color-muted: #64748b;
-  --color-muted-soft: #94a3b8;
-  --color-surface: #f8fafc;
-  --color-card: #ffffff;
-  --color-accent: #2563eb;
-  --color-accent-strong: #1d4ed8;
+  --brand: #0056B3;
+  --text: #333333;
+  --bg-1: #FFFFFF;
+  --bg-2: #F7F9FC;
+  --accent-teal: #009688;
+  --accent-green: #28A745;
+  --accent-orange: #FF9800;
+  --accent-purple: #673AB7;
+  --color-base: #10213F;
+  --color-text: var(--text);
+  --color-muted: #5a667a;
+  --color-muted-soft: #8d99ad;
+  --color-surface: var(--bg-2);
+  --color-card: var(--bg-1);
+  --color-accent: var(--brand);
+  --color-accent-strong: #00448f;
   --color-secondary: #f97316;
-  --color-border: #e2e8f0;
-  --color-border-strong: #cbd5f5;
-  --shadow-card: 0 18px 45px rgba(15, 23, 42, 0.12);
-  --shadow-soft: 0 8px 24px rgba(15, 23, 42, 0.08);
-  --radius-card: 1.25rem;
+  --color-border: #d6e1f2;
+  --color-border-strong: #b7c9e6;
+  --shadow-card: 0 24px 50px rgba(16, 33, 63, 0.08);
+  --shadow-soft: 0 12px 32px rgba(16, 33, 63, 0.08);
+  --shadow-accordion: 0 2px 6px rgba(0, 0, 0, 0.08);
+  --radius-card: 1rem;
   --radius-pill: 999px;
-  --max-site-width: 72rem;
-  --max-content-width: 46rem;
-  --transition-fast: 200ms ease;
+  --max-site-width: 65rem;
+  --max-content-width: 48rem;
+  --transition-fast: 180ms ease;
   --transition-slow: 320ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -542,22 +551,24 @@ main.container {
 
 .post {
   background: var(--color-card);
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: calc(var(--radius-card) + 0.25rem);
   box-shadow: var(--shadow-card);
-  padding: clamp(2rem, 1.6rem + 1.5vw, 3.5rem);
-  max-width: calc(var(--max-content-width) + 22rem);
+  padding: clamp(2rem, 1.4rem + 1.2vw, 3rem);
   margin: 0 auto;
+  max-width: var(--max-site-width);
+  display: grid;
+  gap: 1.5rem;
 }
 
 .post__header {
-  padding-bottom: 1.75rem;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-  margin-bottom: 2.5rem;
+  display: grid;
+  gap: 0.75rem;
+  padding-bottom: 1.5rem;
+  border-bottom: none;
 }
 
 .post__title {
-  margin-bottom: 0.75rem;
+  margin: 0;
 }
 
 .post__excerpt {
@@ -566,56 +577,77 @@ main.container {
   font-size: 1.05rem;
 }
 
-.post__content-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 2.75rem;
-}
-
-.post__content-column {
-  max-width: var(--max-content-width);
-  width: 100%;
-}
-
-.post__intro {
-  margin-bottom: 2.5rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(37, 99, 235, 0.18);
-  background: rgba(37, 99, 235, 0.08);
-  color: var(--color-muted);
-}
-
-.post__body > * {
-  margin-top: 0;
-}
-
-.post__body > * + * {
-  margin-top: 1.75rem;
-}
-
-.post__body ul,
-.post__body ol {
-  padding-left: 1.5rem;
-}
-
-.post__body-content {
+.post__content {
   display: grid;
   gap: 1.75rem;
 }
 
+.post__intro {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.85rem;
+  border-left: 4px solid var(--brand);
+  background: linear-gradient(135deg, rgba(0, 86, 179, 0.12), rgba(0, 86, 179, 0.05));
+  color: var(--color-muted);
+  box-shadow: 0 6px 20px rgba(16, 33, 63, 0.08);
+}
+
+.post__sections {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.post__body-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .post-section {
-  padding-top: 1.75rem;
-  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  --section-accent: var(--brand);
+  --section-accent-muted: rgba(0, 86, 179, 0.12);
+  --section-accent-strong: rgba(0, 86, 179, 0.22);
+  --section-accent-icon-bg: rgba(0, 86, 179, 0.18);
+  background: var(--bg-1);
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-accordion);
+  border: 1px solid rgba(16, 33, 63, 0.05);
+  overflow: hidden;
 }
 
-.post-section:first-of-type {
-  border-top: none;
-  padding-top: 0;
+.post-section:nth-of-type(even) {
+  background: var(--bg-2);
 }
 
-.post-section__title {
-  margin: 0 0 0.75rem;
+.post-section[data-accent="teal"] {
+  --section-accent: var(--accent-teal);
+  --section-accent-muted: rgba(0, 150, 136, 0.12);
+  --section-accent-strong: rgba(0, 150, 136, 0.22);
+  --section-accent-icon-bg: rgba(0, 150, 136, 0.18);
+}
+
+.post-section[data-accent="green"] {
+  --section-accent: var(--accent-green);
+  --section-accent-muted: rgba(40, 167, 69, 0.12);
+  --section-accent-strong: rgba(40, 167, 69, 0.22);
+  --section-accent-icon-bg: rgba(40, 167, 69, 0.18);
+}
+
+.post-section[data-accent="orange"] {
+  --section-accent: var(--accent-orange);
+  --section-accent-muted: rgba(255, 152, 0, 0.14);
+  --section-accent-strong: rgba(255, 152, 0, 0.26);
+  --section-accent-icon-bg: rgba(255, 152, 0, 0.2);
+}
+
+.post-section[data-accent="purple"] {
+  --section-accent: var(--accent-purple);
+  --section-accent-muted: rgba(103, 58, 183, 0.14);
+  --section-accent-strong: rgba(103, 58, 183, 0.26);
+  --section-accent-icon-bg: rgba(103, 58, 183, 0.2);
+}
+
+.post-section__heading {
+  margin: 0;
 }
 
 .post-section__toggle {
@@ -623,252 +655,109 @@ main.container {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: calc(var(--radius-card) - 0.6rem);
-  border: 1px solid transparent;
-  background: rgba(37, 99, 235, 0.05);
+  gap: 1rem;
+  padding: 1.1rem 1.5rem;
+  min-height: 44px;
+  border: none;
+  background: var(--section-accent-muted);
   color: var(--color-base);
   font-size: 1.1rem;
   font-weight: 600;
   text-align: left;
   cursor: pointer;
-  transition: background var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .post-section__toggle:hover,
 .post-section__toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.12);
-  border-color: rgba(37, 99, 235, 0.3);
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  background: var(--section-accent-strong);
+  box-shadow: 0 8px 18px rgba(16, 33, 63, 0.12);
+}
+
+.post-section__toggle:focus-visible {
+  outline: 3px solid rgba(0, 86, 179, 0.35);
+  outline-offset: 2px;
 }
 
 .post-section__toggle[aria-expanded="true"] {
-  background: rgba(37, 99, 235, 0.09);
-  border-color: rgba(37, 99, 235, 0.24);
+  background: var(--section-accent-strong);
 }
 
 .post-section__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 0.75rem;
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--color-accent-strong);
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.9rem;
+  background: var(--section-accent-icon-bg);
+  color: var(--section-accent);
   flex-shrink: 0;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
 }
 
 .post-section__icon-svg {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: currentColor;
 }
 
 .post-section__label {
   flex: 1;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
 }
 
 .post-section__chevron svg {
   width: 1rem;
   height: 1rem;
-  transition: transform var(--transition-fast);
-  color: var(--color-accent);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+  color: var(--section-accent);
+}
+
+.post-section__toggle:hover .post-section__icon,
+.post-section__toggle[aria-expanded="true"] .post-section__icon {
+  color: var(--section-accent);
+  background: rgba(255, 255, 255, 0.85);
 }
 
 .post-section__toggle[aria-expanded="true"] .post-section__chevron svg {
   transform: rotate(180deg);
 }
 
-.post-section__content {
-  margin-top: 1.25rem;
+.post-section__panel {
   overflow: hidden;
-  transition: max-height var(--transition-slow), opacity var(--transition-slow);
-}
-
-.post-section__content[data-open="false"] {
-  opacity: 0;
-}
-
-.post-section__content[data-open="true"] {
+  transition: max-height var(--transition-slow), opacity 220ms ease;
+  max-height: none;
   opacity: 1;
 }
 
-.post__toc {
-  display: none;
+.post-section__panel[data-open="false"] {
+  opacity: 0;
+  pointer-events: none;
 }
 
-.post__toc-inner {
-  background: var(--color-card);
-  border-radius: var(--radius-card);
-  padding: 1.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 1.25rem;
+.post-section__panel-inner {
+  padding: 1.5rem 1.5rem 1.75rem;
 }
 
-.post__toc-title {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  font-size: 1.05rem;
-  color: var(--color-base);
+.post-section__panel-inner > *:first-child {
+  margin-top: 0;
 }
 
-.post__toc-title-icon svg {
-  width: 1.35rem;
-  height: 1.35rem;
-  color: var(--color-accent);
+.post-section__panel-inner > *:last-child {
+  margin-bottom: 0;
 }
 
-.post__toc-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.toc-item {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.toc-item__row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.toc-item__link {
-  color: var(--color-base);
-  text-decoration: none;
-  font-weight: 600;
-  line-height: 1.35;
-}
-
-.toc-item__link:hover,
-.toc-item__link:focus {
-  color: var(--color-accent-strong);
-}
-
-.toc-item__toggle {
-  border: none;
-  border-radius: 999px;
-  width: 2rem;
-  height: 2rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--color-accent);
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
-}
-
-.toc-item__toggle:hover,
-.toc-item__toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.22);
-  color: var(--color-accent-strong);
-}
-
-.toc-item__toggle svg {
-  width: 0.85rem;
-  height: 0.85rem;
-  transition: transform var(--transition-fast);
-}
-
-.toc-item__toggle.is-open svg,
-.toc-item__toggle[aria-expanded="true"] svg {
-  transform: rotate(180deg);
-}
-
-.toc-sublist {
-  list-style: none;
-  margin: 0;
-  padding: 0 0 0 1.4rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.toc-sublist__link {
-  color: var(--color-muted);
-  text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.toc-sublist__link:hover,
-.toc-sublist__link:focus {
-  color: var(--color-accent);
-}
-
-.post__toc-mobile {
-  display: block;
-}
-
-.post__toc-toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.85rem 1.1rem;
-  border-radius: var(--radius-pill);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: var(--color-card);
-  font-weight: 600;
-  cursor: pointer;
-  color: var(--color-base);
-  box-shadow: var(--shadow-soft);
-  transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.post__toc-toggle:hover,
-.post__toc-toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.08);
-  border-color: rgba(37, 99, 235, 0.2);
-}
-
-.post__toc-toggle.is-open,
-.post__toc-toggle[aria-expanded="true"] {
-  border-color: rgba(37, 99, 235, 0.32);
-  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.18);
-}
-
-.post__toc-toggle-icon svg,
-.post__toc-toggle-chevron svg {
-  width: 1.1rem;
-  height: 1.1rem;
-  color: var(--color-accent);
-  transition: transform var(--transition-fast);
-}
-
-.post__toc-toggle[aria-expanded="true"] .post__toc-toggle-chevron svg {
-  transform: rotate(180deg);
-}
-
-.post__toc-panel {
-  margin-top: 1rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: var(--radius-card);
-  background: var(--color-card);
-  padding: 1.25rem 1.5rem;
-  box-shadow: var(--shadow-soft);
-}
 
 .post__disclaimer {
-  margin-top: 2.75rem;
-  padding: 1.25rem 1.5rem;
-  background: rgba(15, 23, 42, 0.04);
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  font-size: 0.95rem;
+  margin: 0;
+  padding: 1rem 1.25rem;
+  background: rgba(16, 33, 63, 0.05);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(16, 33, 63, 0.08);
+  font-size: 0.9375rem;
   color: var(--color-muted);
 }
 
@@ -897,56 +786,56 @@ main.container {
 }
 
 .affiliate-card {
-  margin: 2.75rem 0;
-  padding: clamp(1.5rem, 1.2rem + 1vw, 2rem);
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(37, 99, 235, 0.2);
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(249, 250, 255, 0.95));
-  box-shadow: var(--shadow-soft);
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(0, 86, 179, 0.18);
+  background: linear-gradient(135deg, rgba(0, 86, 179, 0.12), rgba(0, 86, 179, 0.04));
+  box-shadow: 0 12px 28px rgba(0, 86, 179, 0.12);
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .affiliate-card__media {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .affiliate-card__media img {
-  width: 100%;
-  max-width: 120px;
-  height: auto;
-  border-radius: calc(var(--radius-card) - 0.75rem);
+  width: 96px;
+  height: 96px;
+  object-fit: contain;
+  border-radius: 0.75rem;
 }
 
 .affiliate-card__icon {
-  width: 110px;
-  height: 110px;
-  border-radius: var(--radius-card);
-  background: rgba(37, 99, 235, 0.14);
+  width: 88px;
+  height: 88px;
+  border-radius: 0.75rem;
+  background: rgba(0, 86, 179, 0.18);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-accent);
+  color: var(--brand);
 }
 
 .affiliate-card__body {
   display: grid;
-  gap: 0.9rem;
+  gap: 0.75rem;
 }
 
 .affiliate-card__eyebrow {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--color-accent-strong);
+  color: var(--brand);
   font-weight: 700;
 }
 
 .affiliate-card__title {
   margin: 0;
-  font-size: clamp(1.35rem, 1.2rem + 0.4vw, 1.65rem);
+  font-size: clamp(1.25rem, 1.15rem + 0.3vw, 1.5rem);
   color: var(--color-base);
 }
 
@@ -958,12 +847,12 @@ main.container {
 .affiliate-card__actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .affiliate-card__disclaimer {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
   color: var(--color-muted-soft);
 }
 
@@ -981,116 +870,44 @@ main.container {
   color: var(--color-muted);
 }
 
-.site-footer {
-  background: var(--color-base);
-  color: #f8fafc;
-  padding: 3.5rem 0;
-  margin-top: 4rem;
+.legal-footer {
+  background: var(--bg-2);
+  padding: 2rem 0;
+  margin-top: 3rem;
+  border-top: 1px solid rgba(16, 33, 63, 0.08);
 }
 
-.site-footer__container {
-  display: grid;
-  gap: 2.5rem;
-  align-items: start;
-}
-
-.site-footer__brand {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.site-footer__logo {
-  font-size: 1.45rem;
-  font-weight: 700;
-  color: #f8fafc;
-  text-decoration: none;
-}
-
-.site-footer__summary {
-  margin: 0;
-  color: rgba(226, 232, 240, 0.85);
-  max-width: 30rem;
-}
-
-.site-footer__copyright {
-  margin: 0;
-  color: rgba(148, 163, 184, 0.85);
-  font-size: 0.95rem;
-}
-
-.site-footer__title {
-  margin: 0 0 1rem;
-  font-size: 1.05rem;
+.legal-footer__container {
   display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  color: #f8fafc;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
-.site-footer__title-icon svg {
-  width: 1.1rem;
-  height: 1.1rem;
-  color: rgba(148, 197, 255, 0.85);
-}
-
-.site-footer__links {
-  list-style: none;
+.legal-footer__brand {
   margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
 }
 
-.site-footer__link-item a {
-  color: rgba(226, 232, 240, 0.95);
-  text-decoration: none;
+.legal-footer__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+}
+
+.legal-footer__link {
+  color: var(--brand);
   font-weight: 600;
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.1rem;
 }
 
-.site-footer__link-item a:hover,
-.site-footer__link-item a:focus {
-  color: rgba(148, 197, 255, 0.98);
-}
-
-.site-footer__toc .post__toc-list {
-  gap: 0.6rem;
-}
-
-.site-footer__toc .toc-item__link {
-  color: rgba(226, 232, 240, 0.95);
-}
-
-.site-footer__toc .toc-item__link:hover,
-.site-footer__toc .toc-item__link:focus {
-  color: rgba(148, 197, 255, 0.98);
-}
-
-.site-footer__toc .toc-item__toggle {
-  background: rgba(255, 255, 255, 0.12);
-  color: #f8fafc;
-}
-
-.site-footer__toc .toc-item__toggle:hover,
-.site-footer__toc .toc-item__toggle:focus-visible {
-  background: rgba(255, 255, 255, 0.22);
-}
-
-.site-footer__toc .toc-sublist__link {
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.site-footer__toc .toc-sublist__link:hover,
-.site-footer__toc .toc-sublist__link:focus {
-  color: rgba(148, 197, 255, 0.98);
-}
-
-.site-footer__toc .toc-item__toggle svg,
-.site-footer__toc .post__toc-title-icon svg {
-  color: rgba(148, 197, 255, 0.85);
-}
-
-.site-footer__toc .post__toc-title {
-  color: #f8fafc;
+.legal-footer__link:hover,
+.legal-footer__link:focus {
+  color: var(--color-accent-strong);
+  text-decoration: underline;
 }
 
 .post-page .site-main {
@@ -1127,12 +944,15 @@ main.container {
   }
 
   .affiliate-card {
-    grid-template-columns: minmax(100px, 140px) 1fr;
+    grid-template-columns: auto 1fr;
     align-items: center;
+    gap: 1.5rem;
   }
 
-  .site-footer__container {
-    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  .legal-footer__container {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 }
 
@@ -1143,24 +963,7 @@ main.container {
   }
 
   .post {
-    padding: clamp(2.5rem, 2rem + 1vw, 3.5rem);
-  }
-
-  .post__content-grid {
-    display: grid;
-    grid-template-columns: minmax(0, var(--max-content-width)) minmax(16rem, 20rem);
-    gap: 3rem;
-    align-items: start;
-  }
-
-  .post__toc {
-    display: block;
-    position: sticky;
-    top: 7.5rem;
-  }
-
-  .post__toc-mobile {
-    display: none;
+    padding: clamp(2.25rem, 1.8rem + 1vw, 3.25rem);
   }
 }
 

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/battery-free-luggage-scale-shake-to-charge/index.html
+++ b/blog/battery-free-luggage-scale-shake-to-charge/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,174 +249,25 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#1-what-battery-free-shake-to-charge-really-means">1) What “Battery-Free / Shake-to-Charge” Really Means</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale">2) Step-by-Step: How to Use a Battery-Free (Shake-to-Charge) Luggage Scale</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#3-accuracy-what-to-expect-and-how-to-improve-it">3) Accuracy: What to Expect (and How to Improve It)</a>
-        
-        
-        <button class="toc-item__toggle" type="button" aria-expanded="false" aria-controls="mobile-toc-sublist-3">
-          <span class="visually-hidden">Toggle subsections for 3) Accuracy: What to Expect (and How to Improve It)</span>
-          
-  
-    
-  
-  
-    <svg class="icon toc-item__chevron" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-
-        </button>
-        
-      </div>
-      
-      <ol class="toc-sublist" id="mobile-toc-sublist-3" hidden>
-        
-        <li class="toc-sublist__item">
-          <a class="toc-sublist__link" href="#quick-calibration-confidence-check-at-home">Quick calibration confidence check (at home)</a>
-        </li>
-        
-      </ol>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#4-shake-to-charge-how-much-shaking-is-enough">4) Shake-to-Charge: How Much Shaking Is “Enough”?</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#5-best-practices-for-reliable-results">5) Best Practices for Reliable Results</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#6-troubleshooting-fast-answers">6) Troubleshooting (Fast Answers)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#7-packing-smarter-with-a-scale-before-after">7) Packing Smarter With a Scale (Before &amp; After)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#8-battery-free-vs-battery-powered-which-should-you-buy">8) Battery-Free vs Battery-Powered: Which Should You Buy?</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#9-safety-handling">9) Safety &amp; Handling</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#10-quick-start-checklist-print-or-save">10) Quick Start Checklist (Print or Save)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#final-take">Final Take</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
-          </div>
-          
-
-          <div class="post__body">
-            
-            
-            <div class="post__intro">
-              <p><strong>Short version:</strong> if you keep seeing surprise fees at the check-in counter, a scale at home is the cheapest insurance you can buy. If it’s <strong>battery-free</strong> and <strong>shake-to-charge</strong>, it’s even better—no coin cells to hunt for, no dead display when you need it. This guide explains how kinetic charging works, how to use the scale correctly, and how to get <strong>repeatable, accurate readings</strong> every time.</p>
+          <div class="post__intro">
+            <p><strong>Short version:</strong> if you keep seeing surprise fees at the check-in counter, a scale at home is the cheapest insurance you can buy. If it’s <strong>battery-free</strong> and <strong>shake-to-charge</strong>, it’s even better—no coin cells to hunt for, no dead display when you need it. This guide explains how kinetic charging works, how to use the scale correctly, and how to get <strong>repeatable, accurate readings</strong> every time.</p>
 <blockquote>
 <p><strong>Why this matters:</strong> Airlines enforce weight. Getting it right at home saves time, stress, and money. A battery-free, shake-to-charge luggage scale makes the process reliable because it’s always “ready.”</p>
 </blockquote>
 <hr>
-            </div>
+          </div>
+          
+          <div class="post__sections" data-accordion>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="1-what-battery-free-shake-to-charge-really-means">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-1-what-battery-free-shake-to-charge-really-means" data-section-toggle data-section="1-what-battery-free-shake-to-charge-really-means">
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="1-what-battery-free-shake-to-charge-really-means" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-1-what-battery-free-shake-to-charge-really-means" type="button" aria-expanded="true" aria-controls="section-content-1-what-battery-free-shake-to-charge-really-means" data-accordion-trigger data-section="1-what-battery-free-shake-to-charge-really-means">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -441,8 +292,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-1-what-battery-free-shake-to-charge-really-means" data-collapsible>
-                <p>A battery-free scale uses a <strong>kinetic energy generator</strong> inside the handle. When you shake the device briskly, a tiny magnet moves within a coil and produces a charge that powers the display and sensor for a short window—long enough to weigh your bag. Think of it like a hand-crank flashlight, but optimized for quick bursts of energy.</p>
+              <div class="post-section__panel" id="section-content-1-what-battery-free-shake-to-charge-really-means" role="region" aria-labelledby="section-trigger-1-what-battery-free-shake-to-charge-really-means" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>A battery-free scale uses a <strong>kinetic energy generator</strong> inside the handle. When you shake the device briskly, a tiny magnet moves within a coil and produces a charge that powers the display and sensor for a short window—long enough to weigh your bag. Think of it like a hand-crank flashlight, but optimized for quick bursts of energy.</p>
 <p><strong>Practical takeaways:</strong></p>
 <ul>
 <li>You don’t store long-term power—<strong>you generate it on demand</strong> with 3–5 seconds of firm shaking.</li>
@@ -450,6 +302,7 @@
 <li>If the display dims, <strong>shake again</strong> for a fresh burst. No coin cells, no chargers.</li>
 </ul>
 <hr>
+                </div>
               </div>
             </section>
             
@@ -458,7 +311,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -492,9 +345,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" data-section-toggle data-section="2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" data-accordion-trigger data-section="2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -520,8 +376,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" data-collapsible>
-                <p>Follow this routine and you’ll get consistent results.</p>
+              <div class="post-section__panel" id="section-content-2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" role="region" aria-labelledby="section-trigger-2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Follow this routine and you’ll get consistent results.</p>
 <ol>
 <li>
 <p><strong>Shake to wake.</strong><br>
@@ -550,13 +407,17 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </ol>
 <p><strong>Pro tip:</strong> Weigh twice. If the two numbers are within ~0.2 lb (100 g), you’re solid.</p>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="3-accuracy-what-to-expect-and-how-to-improve-it">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-3-accuracy-what-to-expect-and-how-to-improve-it" data-section-toggle data-section="3-accuracy-what-to-expect-and-how-to-improve-it">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="3-accuracy-what-to-expect-and-how-to-improve-it" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-3-accuracy-what-to-expect-and-how-to-improve-it" type="button" aria-expanded="true" aria-controls="section-content-3-accuracy-what-to-expect-and-how-to-improve-it" data-accordion-trigger data-section="3-accuracy-what-to-expect-and-how-to-improve-it">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -583,8 +444,9 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-3-accuracy-what-to-expect-and-how-to-improve-it" data-collapsible>
-                <p>Quality luggage scales—battery-free or not—are typically accurate within <strong>±0.2–0.4 lb</strong> (100–200 g) when used correctly. The biggest sources of error aren’t the electronics; they’re <strong>human factors</strong>:</p>
+              <div class="post-section__panel" id="section-content-3-accuracy-what-to-expect-and-how-to-improve-it" role="region" aria-labelledby="section-trigger-3-accuracy-what-to-expect-and-how-to-improve-it" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Quality luggage scales—battery-free or not—are typically accurate within <strong>±0.2–0.4 lb</strong> (100–200 g) when used correctly. The biggest sources of error aren’t the electronics; they’re <strong>human factors</strong>:</p>
 <ul>
 <li><strong>Jerky lifting</strong> introduces momentum that reads as extra weight.<br>
 → Lift smoothly and hold steady.</li>
@@ -600,13 +462,17 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 <li>If results cluster tightly (e.g., 4.98–5.04 lb), your scale is good.</li>
 </ol>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="4-shake-to-charge-how-much-shaking-is-enough">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-4-shake-to-charge-how-much-shaking-is-enough" data-section-toggle data-section="4-shake-to-charge-how-much-shaking-is-enough">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="4-shake-to-charge-how-much-shaking-is-enough" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-4-shake-to-charge-how-much-shaking-is-enough" type="button" aria-expanded="true" aria-controls="section-content-4-shake-to-charge-how-much-shaking-is-enough" data-accordion-trigger data-section="4-shake-to-charge-how-much-shaking-is-enough">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -633,8 +499,9 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-4-shake-to-charge-how-much-shaking-is-enough" data-collapsible>
-                <p>Most users under-shake. Aim for <strong>3–5 seconds</strong> of <strong>firm</strong>, wrist-driven shaking. You’re not trying to break the device—just brisk movement to spin the internal generator. If the screen <strong>fades during weighing</strong>, pause, set the bag down, and <strong>shake again</strong>.</p>
+              <div class="post-section__panel" id="section-content-4-shake-to-charge-how-much-shaking-is-enough" role="region" aria-labelledby="section-trigger-4-shake-to-charge-how-much-shaking-is-enough" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Most users under-shake. Aim for <strong>3–5 seconds</strong> of <strong>firm</strong>, wrist-driven shaking. You’re not trying to break the device—just brisk movement to spin the internal generator. If the screen <strong>fades during weighing</strong>, pause, set the bag down, and <strong>shake again</strong>.</p>
 <p><strong>Signs you need a fresh charge:</strong></p>
 <ul>
 <li>Display lights but dims quickly.</li>
@@ -642,13 +509,17 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 <li>Auto-hold doesn’t engage.</li>
 </ul>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="5-best-practices-for-reliable-results">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-5-best-practices-for-reliable-results" data-section-toggle data-section="5-best-practices-for-reliable-results">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="5-best-practices-for-reliable-results" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-5-best-practices-for-reliable-results" type="button" aria-expanded="true" aria-controls="section-content-5-best-practices-for-reliable-results" data-accordion-trigger data-section="5-best-practices-for-reliable-results">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -674,21 +545,26 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-5-best-practices-for-reliable-results" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-5-best-practices-for-reliable-results" role="region" aria-labelledby="section-trigger-5-best-practices-for-reliable-results" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li><strong>Use the same motion every time.</strong> Consistency beats perfection.</li>
 <li><strong>Check straps and buckles.</strong> A half-latched hook can slip, adding movement.</li>
 <li><strong>Stand tall.</strong> Bending or swaying adds noise to the reading.</li>
 <li><strong>Mind the “last pound.”</strong> If your airline limit is 50 lb (23 kg), aim for <strong>48–49 lb</strong> at home to allow for scale differences and souvenirs.</li>
 </ul>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="6-troubleshooting-fast-answers">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-6-troubleshooting-fast-answers" data-section-toggle data-section="6-troubleshooting-fast-answers">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="6-troubleshooting-fast-answers" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-6-troubleshooting-fast-answers" type="button" aria-expanded="true" aria-controls="section-content-6-troubleshooting-fast-answers" data-accordion-trigger data-section="6-troubleshooting-fast-answers">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -713,8 +589,9 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-6-troubleshooting-fast-answers" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-6-troubleshooting-fast-answers" role="region" aria-labelledby="section-trigger-6-troubleshooting-fast-answers" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>
 <p><strong>The screen won’t turn on.</strong><br>
 → Shake longer (briskly), then wait a second. If no response, check if the screen cable or generator is loose (rare) and consult the manual.</p>
@@ -733,13 +610,17 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </li>
 </ul>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="7-packing-smarter-with-a-scale-before-after">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-7-packing-smarter-with-a-scale-before-after" data-section-toggle data-section="7-packing-smarter-with-a-scale-before-after">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="7-packing-smarter-with-a-scale-before-after" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-7-packing-smarter-with-a-scale-before-after" type="button" aria-expanded="true" aria-controls="section-content-7-packing-smarter-with-a-scale-before-after" data-accordion-trigger data-section="7-packing-smarter-with-a-scale-before-after">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -765,8 +646,9 @@ Lower the bag slowly. If you need to re-check, <strong>shake again</strong> and 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-7-packing-smarter-with-a-scale-before-after" data-collapsible>
-                <p>Use the scale twice—<strong>before you leave</strong>, and <strong>before you come home</strong>.</p>
+              <div class="post-section__panel" id="section-content-7-packing-smarter-with-a-scale-before-after" role="region" aria-labelledby="section-trigger-7-packing-smarter-with-a-scale-before-after" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Use the scale twice—<strong>before you leave</strong>, and <strong>before you come home</strong>.</p>
 <ul>
 <li><strong>Outbound:</strong>
 <ol>
@@ -780,13 +662,17 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 <p><strong>Margin beats perfection.</strong> Target 1–2 lb under the limit—your future self will thank you at the counter.</p>
 </blockquote>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="8-battery-free-vs-battery-powered-which-should-you-buy">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-8-battery-free-vs-battery-powered-which-should-you-buy" data-section-toggle data-section="8-battery-free-vs-battery-powered-which-should-you-buy">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="8-battery-free-vs-battery-powered-which-should-you-buy" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-8-battery-free-vs-battery-powered-which-should-you-buy" type="button" aria-expanded="true" aria-controls="section-content-8-battery-free-vs-battery-powered-which-should-you-buy" data-accordion-trigger data-section="8-battery-free-vs-battery-powered-which-should-you-buy">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -811,8 +697,9 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-8-battery-free-vs-battery-powered-which-should-you-buy" data-collapsible>
-                <table>
+              <div class="post-section__panel" id="section-content-8-battery-free-vs-battery-powered-which-should-you-buy" role="region" aria-labelledby="section-trigger-8-battery-free-vs-battery-powered-which-should-you-buy" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <table>
 <thead>
 <tr>
 <th>Feature</th>
@@ -850,13 +737,17 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 </table>
 <p><strong>Bottom line:</strong> If you want a scale that’s <strong>always ready</strong>, battery-free wins. If you prefer “pick up and weigh” and don’t mind coin cells, battery-powered can be slightly simpler in the moment.</p>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="9-safety-handling">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-9-safety-handling" data-section-toggle data-section="9-safety-handling">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="9-safety-handling" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-9-safety-handling" type="button" aria-expanded="true" aria-controls="section-content-9-safety-handling" data-accordion-trigger data-section="9-safety-handling">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -881,20 +772,25 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-9-safety-handling" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-9-safety-handling" role="region" aria-labelledby="section-trigger-9-safety-handling" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Don’t swing the bag like a kettlebell—steady is safer and more accurate.</li>
 <li>Check baggage handles for cracks before lifting.</li>
 <li>Keep fingers clear of hard edges on metal handles.</li>
 </ul>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="10-quick-start-checklist-print-or-save">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-10-quick-start-checklist-print-or-save" data-section-toggle data-section="10-quick-start-checklist-print-or-save">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="10-quick-start-checklist-print-or-save" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-10-quick-start-checklist-print-or-save" type="button" aria-expanded="true" aria-controls="section-content-10-quick-start-checklist-print-or-save" data-accordion-trigger data-section="10-quick-start-checklist-print-or-save">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -921,8 +817,9 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-10-quick-start-checklist-print-or-save" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-10-quick-start-checklist-print-or-save" role="region" aria-labelledby="section-trigger-10-quick-start-checklist-print-or-save" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>✅ Shake 3–5 seconds until the screen is bright</li>
 <li>✅ Zero the scale</li>
 <li>✅ Hook centered, strap flat</li>
@@ -931,13 +828,17 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 <li>✅ Aim for <strong>48–49 lb</strong> on a 50 lb limit</li>
 </ul>
 <hr>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="final-take">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-final-take" data-section-toggle data-section="final-take">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="final-take" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-final-take" type="button" aria-expanded="true" aria-controls="section-content-final-take" data-accordion-trigger data-section="final-take">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -962,326 +863,37 @@ Souvenirs add up. Weigh the full bag once more. Shift heavy items into a carry-o
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-final-take" data-collapsible>
-                <p>A <strong>battery-free, shake-to-charge luggage scale</strong> removes the most common failure point—dead batteries—while staying compact, accurate, and easy to use. With a 30-second routine and a bit of consistency, you’ll travel lighter, skip the last-minute repack at the airport, and avoid those painful overweight fees for good.</p>
+              <div class="post-section__panel" id="section-content-final-take" role="region" aria-labelledby="section-trigger-final-take" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>A <strong>battery-free, shake-to-charge luggage scale</strong> removes the most common failure point—dead batteries—while staying compact, accurate, and easy to use. With a 30-second routine and a bit of consistency, you’ll travel lighter, skip the last-minute repack at the airport, and avoid those painful overweight fees for good.</p>
 <p><strong>Try it once</strong> before your next trip—you’ll never go back to guessing.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#1-what-battery-free-shake-to-charge-really-means">1) What “Battery-Free / Shake-to-Charge” Really Means</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale">2) Step-by-Step: How to Use a Battery-Free (Shake-to-Charge) Luggage Scale</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#3-accuracy-what-to-expect-and-how-to-improve-it">3) Accuracy: What to Expect (and How to Improve It)</a>
-        
-        
-        <button class="toc-item__toggle" type="button" aria-expanded="false" aria-controls="desktop-toc-sublist-3">
-          <span class="visually-hidden">Toggle subsections for 3) Accuracy: What to Expect (and How to Improve It)</span>
-          
-  
-    
-  
-  
-    <svg class="icon toc-item__chevron" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-
-        </button>
-        
-      </div>
-      
-      <ol class="toc-sublist" id="desktop-toc-sublist-3" hidden>
-        
-        <li class="toc-sublist__item">
-          <a class="toc-sublist__link" href="#quick-calibration-confidence-check-at-home">Quick calibration confidence check (at home)</a>
-        </li>
-        
-      </ol>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#4-shake-to-charge-how-much-shaking-is-enough">4) Shake-to-Charge: How Much Shaking Is “Enough”?</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#5-best-practices-for-reliable-results">5) Best Practices for Reliable Results</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#6-troubleshooting-fast-answers">6) Troubleshooting (Fast Answers)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#7-packing-smarter-with-a-scale-before-after">7) Packing Smarter With a Scale (Before &amp; After)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#8-battery-free-vs-battery-powered-which-should-you-buy">8) Battery-Free vs Battery-Powered: Which Should You Buy?</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#9-safety-handling">9) Safety &amp; Handling</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#10-quick-start-checklist-print-or-save">10) Quick Start Checklist (Print or Save)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#final-take">Final Take</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#1-what-battery-free-shake-to-charge-really-means">1) What “Battery-Free / Shake-to-Charge” Really Means</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#2-step-by-step-how-to-use-a-battery-free-shake-to-charge-luggage-scale">2) Step-by-Step: How to Use a Battery-Free (Shake-to-Charge) Luggage Scale</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#3-accuracy-what-to-expect-and-how-to-improve-it">3) Accuracy: What to Expect (and How to Improve It)</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-        <button class="toc-item__toggle" type="button" aria-expanded="false" aria-controls="footer-toc-sublist-3">
-          <span class="visually-hidden">Toggle subsections for 3) Accuracy: What to Expect (and How to Improve It)</span>
-          
-  
-    
-  
-  
-    <svg class="icon toc-item__chevron" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-
-        </button>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-      <ol class="toc-sublist" id="footer-toc-sublist-3" hidden>
-        
-        <li class="toc-sublist__item">
-          <a class="toc-sublist__link" href="#quick-calibration-confidence-check-at-home">Quick calibration confidence check (at home)</a>
-        </li>
-        
-      </ol>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#4-shake-to-charge-how-much-shaking-is-enough">4) Shake-to-Charge: How Much Shaking Is “Enough”?</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#5-best-practices-for-reliable-results">5) Best Practices for Reliable Results</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#6-troubleshooting-fast-answers">6) Troubleshooting (Fast Answers)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#7-packing-smarter-with-a-scale-before-after">7) Packing Smarter With a Scale (Before &amp; After)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#8-battery-free-vs-battery-powered-which-should-you-buy">8) Battery-Free vs Battery-Powered: Which Should You Buy?</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#9-safety-handling">9) Safety &amp; Handling</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#10-quick-start-checklist-print-or-save">10) Quick Start Checklist (Print or Save)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#final-take">Final Take</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/digital-luggage-scale/index.html
+++ b/blog/digital-luggage-scale/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,127 +249,17 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#introduction">Introduction</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why It Matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#how-it-works">How It Works</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#key-benefits">Key Benefits</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#comparison">Comparison</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#use-cases">Use Cases</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro Tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#faq">FAQ</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#conclusion-cta">Conclusion + CTA</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
-          </div>
-          
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="introduction">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-introduction" data-section-toggle data-section="introduction">
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="introduction" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-introduction" type="button" aria-expanded="true" aria-controls="section-content-introduction" data-accordion-trigger data-section="introduction">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -396,8 +286,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-introduction" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-introduction" role="region" aria-labelledby="section-trigger-introduction" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -406,6 +297,7 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Introduction. Write Introduction about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
@@ -414,7 +306,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -448,9 +340,14 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -477,8 +374,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -487,13 +385,19 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Why It Matters. Write Why It Matters about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="how-it-works">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-how-it-works" data-section-toggle data-section="how-it-works">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="teal">
+              <h2 class="post-section__heading" id="how-it-works" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-how-it-works" type="button" aria-expanded="true" aria-controls="section-content-how-it-works" data-accordion-trigger data-section="how-it-works">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -520,8 +424,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-how-it-works" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-how-it-works" role="region" aria-labelledby="section-trigger-how-it-works" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -530,13 +435,19 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for How It Works. Write How It Works about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="key-benefits">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-key-benefits" data-section-toggle data-section="key-benefits">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="green">
+              <h2 class="post-section__heading" id="key-benefits" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-key-benefits" type="button" aria-expanded="true" aria-controls="section-content-key-benefits" data-accordion-trigger data-section="key-benefits">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -563,8 +474,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-key-benefits" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-key-benefits" role="region" aria-labelledby="section-trigger-key-benefits" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -573,13 +485,19 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Key Benefits. Write Key Benefits about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="comparison">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-comparison" data-section-toggle data-section="comparison">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="orange">
+              <h2 class="post-section__heading" id="comparison" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-comparison" type="button" aria-expanded="true" aria-controls="section-content-comparison" data-accordion-trigger data-section="comparison">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -604,8 +522,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-comparison" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-comparison" role="region" aria-labelledby="section-trigger-comparison" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -614,13 +533,19 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Comparison. Write Comparison about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="use-cases">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-use-cases" data-section-toggle data-section="use-cases">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="purple">
+              <h2 class="post-section__heading" id="use-cases" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-use-cases" type="button" aria-expanded="true" aria-controls="section-content-use-cases" data-accordion-trigger data-section="use-cases">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -647,8 +572,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-use-cases" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-use-cases" role="region" aria-labelledby="section-trigger-use-cases" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -657,13 +583,17 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Use Cases. Write Use Cases about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -689,8 +619,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -699,13 +630,17 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Pro Tips. Write Pro Tips about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="faq">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-faq" data-section-toggle data-section="faq">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="faq" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-faq" type="button" aria-expanded="true" aria-controls="section-content-faq" data-accordion-trigger data-section="faq">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -731,8 +666,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-faq" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-faq" role="region" aria-labelledby="section-trigger-faq" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -741,13 +677,17 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for FAQ. Write FAQ about &quot;Digital Luggage Scale&quot;...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="conclusion-cta">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-conclusion-cta" data-section-toggle data-section="conclusion-cta">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="conclusion-cta" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-conclusion-cta" type="button" aria-expanded="true" aria-controls="section-content-conclusion-cta" data-accordion-trigger data-section="conclusion-cta">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -772,8 +712,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-conclusion-cta" data-collapsible>
-                <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
+              <div class="post-section__panel" id="section-content-conclusion-cta" role="region" aria-labelledby="section-trigger-conclusion-cta" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <div class="placeholder-block" role="note" aria-label="Draft content placeholder">
   <span class="placeholder-block__icon" aria-hidden="true">
     <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
       <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="currentColor"/>
@@ -782,245 +723,33 @@
   </span>
   <span class="placeholder-block__text"><em>This is placeholder text for Conclusion + CTA. Write Conclusion + CTA about &quot;Digital Luggage Scal...</em></span>
 </div>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#introduction">Introduction</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why It Matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#how-it-works">How It Works</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#key-benefits">Key Benefits</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#comparison">Comparison</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#use-cases">Use Cases</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro Tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#faq">FAQ</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#conclusion-cta">Conclusion + CTA</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#introduction">Introduction</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why It Matters</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#how-it-works">How It Works</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#key-benefits">Key Benefits</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#comparison">Comparison</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#use-cases">Use Cases</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro Tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#faq">FAQ</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#conclusion-cta">Conclusion + CTA</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/durable-luggage-scale-frequent-flyers/index.html
+++ b/blog/durable-luggage-scale-frequent-flyers/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,132 +249,11 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#introduction">Introduction</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-durability-matters-for-frequent-flyers">Why Durability Matters for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#how-a-handheld-luggage-scale-works-simple-breakdown">How a Handheld Luggage Scale Works (Simple Breakdown)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#key-benefits-for-frequent-flyers">Key Benefits for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#comparison-what-to-look-for">Comparison: What to Look For</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#use-cases-for-frequent-flyers">Use Cases for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips-best-practices">Pro Tips &amp; Best Practices</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#frequently-asked-questions-faq">Frequently Asked Questions (FAQ)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#final-checklist-buy-once-fly-often">Final Checklist (Buy Once, Fly Often)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#conclusion-cta">Conclusion &amp; CTA</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
-          </div>
-          
-
-          <div class="post__body">
-            
-            
-            <div class="post__intro">
-              <!-- Hero SVG: one lightweight element -->
+          <div class="post__intro">
+            <!-- Hero SVG: one lightweight element -->
 <div aria-hidden="true" style="margin: 1rem 0 1.25rem 0;">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 240" role="img" aria-label="Handheld durable luggage scale">
   <title>Durable handheld luggage scale</title>
@@ -386,13 +265,16 @@
   <path d="M170,120 v40 m-30,0 h60 m-60,40 q30,20 60,0" stroke="#0F172A" stroke-width="2" fill="none"/>
 </svg>
 </div>
-            </div>
+          </div>
+          
+          <div class="post__sections" data-accordion>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="introduction">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-introduction" data-section-toggle data-section="introduction">
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="introduction" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-introduction" type="button" aria-expanded="true" aria-controls="section-content-introduction" data-accordion-trigger data-section="introduction">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -419,9 +301,11 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-introduction" data-collapsible>
-                <p>If you fly often, baggage weight isn’t an occasional inconvenience—it’s a weekly risk to your wallet and schedule. The wrong scale dies mid-trip, gives flaky readings, or snaps at the hook right when you need it most. A <strong>durable luggage scale</strong> solves that problem by combining <strong>solid construction</strong>, <strong>consistent accuracy</strong>, and <strong>compact design</strong> you can trust from home to the hotel lobby and back to the gate.</p>
+              <div class="post-section__panel" id="section-content-introduction" role="region" aria-labelledby="section-trigger-introduction" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>If you fly often, baggage weight isn’t an occasional inconvenience—it’s a weekly risk to your wallet and schedule. The wrong scale dies mid-trip, gives flaky readings, or snaps at the hook right when you need it most. A <strong>durable luggage scale</strong> solves that problem by combining <strong>solid construction</strong>, <strong>consistent accuracy</strong>, and <strong>compact design</strong> you can trust from home to the hotel lobby and back to the gate.</p>
 <p>This guide explains what “durable” really means for a travel scale, how modern handheld weighers work, the benefits that matter to frequent flyers, what to compare against, and how to use one efficiently on fast turnarounds. We’ll finish with pro tips, a concise FAQ, and a final checklist so you can buy once and travel lighter—literally.</p>
+                </div>
               </div>
             </section>
             
@@ -430,7 +314,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -464,9 +348,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-durability-matters-for-frequent-flyers">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-durability-matters-for-frequent-flyers" data-section-toggle data-section="why-durability-matters-for-frequent-flyers">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-durability-matters-for-frequent-flyers" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-durability-matters-for-frequent-flyers" type="button" aria-expanded="true" aria-controls="section-content-why-durability-matters-for-frequent-flyers" data-accordion-trigger data-section="why-durability-matters-for-frequent-flyers">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -493,16 +380,21 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-durability-matters-for-frequent-flyers" data-collapsible>
-                <p>Frequent flyers face different conditions than occasional travelers: hurried connections, baggage re-packing on terminal floors, crowded hotel rooms, and unpredictable weather. A weak battery door or flimsy hook can fail after a few trips; a soft plastic body can crack in a carry-on pocket.</p>
+              <div class="post-section__panel" id="section-content-why-durability-matters-for-frequent-flyers" role="region" aria-labelledby="section-trigger-why-durability-matters-for-frequent-flyers" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Frequent flyers face different conditions than occasional travelers: hurried connections, baggage re-packing on terminal floors, crowded hotel rooms, and unpredictable weather. A weak battery door or flimsy hook can fail after a few trips; a soft plastic body can crack in a carry-on pocket.</p>
 <p>A <strong>durable luggage scale</strong> prioritizes materials and design choices that resist stress: reinforced housings, metal hooks and straps, shock-absorbing geometry, and clear displays that remain readable in low-light boarding areas. Accuracy also stays stable after dozens of lifts—no “drift” after a month of heavy use.</p>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="how-a-handheld-luggage-scale-works-simple-breakdown">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-how-a-handheld-luggage-scale-works-simple-breakdown" data-section-toggle data-section="how-a-handheld-luggage-scale-works-simple-breakdown">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="how-a-handheld-luggage-scale-works-simple-breakdown" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-how-a-handheld-luggage-scale-works-simple-breakdown" type="button" aria-expanded="true" aria-controls="section-content-how-a-handheld-luggage-scale-works-simple-breakdown" data-accordion-trigger data-section="how-a-handheld-luggage-scale-works-simple-breakdown">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -528,8 +420,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-how-a-handheld-luggage-scale-works-simple-breakdown" data-collapsible>
-                <p>At its core, a handheld scale measures <strong>force</strong> created by your bag’s weight. That force is converted into a <strong>digital reading</strong> via an internal sensor. Here’s the basic flow:</p>
+              <div class="post-section__panel" id="section-content-how-a-handheld-luggage-scale-works-simple-breakdown" role="region" aria-labelledby="section-trigger-how-a-handheld-luggage-scale-works-simple-breakdown" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>At its core, a handheld scale measures <strong>force</strong> created by your bag’s weight. That force is converted into a <strong>digital reading</strong> via an internal sensor. Here’s the basic flow:</p>
 <ol>
 <li><strong>Attach</strong> the hook or strap to your bag’s handle.</li>
 <li><strong>Lift</strong> smoothly so the scale bears the full weight (bag not touching the floor).</li>
@@ -538,13 +431,19 @@
 <li><strong>Display</strong>: the LCD/LED shows a final weight in lb/kg; a <strong>TARE</strong> function subtracts accessories like packing cubes or straps.</li>
 </ol>
 <p><strong>Durability angle:</strong> Robust sensor mounting, metal hardware, and rigid casing help the scale maintain calibration longer and survive knocks in overhead bins and backpacks.</p>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="key-benefits-for-frequent-flyers">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-key-benefits-for-frequent-flyers" data-section-toggle data-section="key-benefits-for-frequent-flyers">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="green">
+              <h2 class="post-section__heading" id="key-benefits-for-frequent-flyers" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-key-benefits-for-frequent-flyers" type="button" aria-expanded="true" aria-controls="section-content-key-benefits-for-frequent-flyers" data-accordion-trigger data-section="key-benefits-for-frequent-flyers">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -571,8 +470,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-key-benefits-for-frequent-flyers" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-key-benefits-for-frequent-flyers" role="region" aria-labelledby="section-trigger-key-benefits-for-frequent-flyers" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li><strong>Reliable construction</strong> — Metal hook/strap hardware and reinforced body resist daily wear.</li>
 <li><strong>Consistent accuracy</strong> — Stable readings reduce surprise fees at check-in.</li>
 <li><strong>Compact &amp; packable</strong> — Fits in a side pocket without adding noticeable weight.</li>
@@ -580,13 +480,19 @@
 <li><strong>Unit flexibility</strong> — Switch lb/kg instantly to match airline standards.</li>
 <li><strong>TARE function</strong> — Zero out add-ons to weigh only what matters.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="comparison-what-to-look-for">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-comparison-what-to-look-for" data-section-toggle data-section="comparison-what-to-look-for">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="orange">
+              <h2 class="post-section__heading" id="comparison-what-to-look-for" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-comparison-what-to-look-for" type="button" aria-expanded="true" aria-controls="section-content-comparison-what-to-look-for" data-accordion-trigger data-section="comparison-what-to-look-for">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -611,8 +517,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-comparison-what-to-look-for" data-collapsible>
-                <p>Use this quick table to evaluate durability and usability at a glance.</p>
+              <div class="post-section__panel" id="section-content-comparison-what-to-look-for" role="region" aria-labelledby="section-trigger-comparison-what-to-look-for" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Use this quick table to evaluate durability and usability at a glance.</p>
 <table>
 <thead>
 <tr>
@@ -655,13 +562,19 @@
 </tbody>
 </table>
 <p><strong>Bottom line:</strong> durability is a stack of small, smart choices—hardware, housing, and firmware working together.</p>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="use-cases-for-frequent-flyers">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-use-cases-for-frequent-flyers" data-section-toggle data-section="use-cases-for-frequent-flyers">
+            
+            
+            
+              
+            
+            <section class="post-section" data-post-section data-accent="purple">
+              <h2 class="post-section__heading" id="use-cases-for-frequent-flyers" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-use-cases-for-frequent-flyers" type="button" aria-expanded="true" aria-controls="section-content-use-cases-for-frequent-flyers" data-accordion-trigger data-section="use-cases-for-frequent-flyers">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -688,19 +601,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-use-cases-for-frequent-flyers" data-collapsible>
-                <p><strong>Frequent flyers</strong>: Weigh checked and carry-on bags before leaving the hotel so you breeze through the scale at check-in.<br>
+              <div class="post-section__panel" id="section-content-use-cases-for-frequent-flyers" role="region" aria-labelledby="section-trigger-use-cases-for-frequent-flyers" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p><strong>Frequent flyers</strong>: Weigh checked and carry-on bags before leaving the hotel so you breeze through the scale at check-in.<br>
 <strong>Multi-city itineraries</strong>: Reweigh after gift purchases or conference swag; shifting weight between bags can avoid fees.<br>
 <strong>International routes</strong>: Quickly flip units (lb/kg) to match airline policies without guesswork.<br>
 <strong>Family trips</strong>: Use the TARE function to subtract packing cubes or child gear straps for true net weight.</p>
 <p>Tip: Keep the scale in an easy-reach pocket; weighing takes &lt;30 seconds when you’re trained.</p>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips-best-practices">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips-best-practices" data-section-toggle data-section="pro-tips-best-practices">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips-best-practices" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips-best-practices" type="button" aria-expanded="true" aria-controls="section-content-pro-tips-best-practices" data-accordion-trigger data-section="pro-tips-best-practices">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -726,8 +644,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips-best-practices" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips-best-practices" role="region" aria-labelledby="section-trigger-pro-tips-best-practices" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li><strong>Lift smoothly and steadily</strong>: rocking adds noise; a 2–3 second hold gives the best lock.</li>
 <li><strong>Use the hold feature</strong>: if the screen locks the reading, you can set the bag down and note the number without re-weighing.</li>
 <li><strong>Mind the handle</strong>: attach to a sturdy, central grip; off-center lifts can skew a couple of ounces.</li>
@@ -735,13 +654,17 @@
 <li><strong>Protect the display</strong>: store the scale screen-inward or in a soft pouch to prevent scratches.</li>
 <li><strong>Know your allowance</strong>: different fare classes and carriers vary; a quick check saves time at the counter.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="frequently-asked-questions-faq">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-frequently-asked-questions-faq" data-section-toggle data-section="frequently-asked-questions-faq">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="frequently-asked-questions-faq" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-frequently-asked-questions-faq" type="button" aria-expanded="true" aria-controls="section-content-frequently-asked-questions-faq" data-accordion-trigger data-section="frequently-asked-questions-faq">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -767,8 +690,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-frequently-asked-questions-faq" data-collapsible>
-                <p><strong>How accurate are handheld luggage scales?</strong><br>
+              <div class="post-section__panel" id="section-content-frequently-asked-questions-faq" role="region" aria-labelledby="section-trigger-frequently-asked-questions-faq" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p><strong>How accurate are handheld luggage scales?</strong><br>
 Quality models maintain accuracy within a small tolerance suitable for airline limits. Consistency matters more than a fractional precision race—if it reads the same across repeated lifts, you can trust your packing decisions.</p>
 <p><strong>Do I need a TARE function?</strong><br>
 It’s useful. If you use organizers, straps, or protective covers, TARE removes their weight so you see the true bag weight without mental math.</p>
@@ -780,13 +704,17 @@ Look for <strong>reinforced housing</strong>, <strong>metal hook/strap hardware<
 Yes. For soft handles, a strap often grips better than a hook. Lift until the bag is fully off the ground for a stable reading.</p>
 <p><strong>Should I weigh at the airport or hotel?</strong><br>
 Hotel first. That way you adjust before leaving. If you buy souvenirs, re-check at the airport curb or lobby and shift items to carry-on if needed.</p>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="final-checklist-buy-once-fly-often">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-final-checklist-buy-once-fly-often" data-section-toggle data-section="final-checklist-buy-once-fly-often">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="final-checklist-buy-once-fly-often" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-final-checklist-buy-once-fly-often" type="button" aria-expanded="true" aria-controls="section-content-final-checklist-buy-once-fly-often" data-accordion-trigger data-section="final-checklist-buy-once-fly-often">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -811,21 +739,26 @@ Hotel first. That way you adjust before leaving. If you buy souvenirs, re-check 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-final-checklist-buy-once-fly-often" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-final-checklist-buy-once-fly-often" role="region" aria-labelledby="section-trigger-final-checklist-buy-once-fly-often" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li><strong>Body &amp; hardware:</strong> Reinforced housing, metal hook/strap, solid buttons.</li>
 <li><strong>Display:</strong> High-contrast digits, hold/lock, easy unit toggle.</li>
 <li><strong>Accuracy:</strong> Consistent repeated readings; stays stable over time.</li>
 <li><strong>Size/weight:</strong> Compact and truly packable for weekly use.</li>
 <li><strong>Features:</strong> TARE, lb/kg switch, quick wake or battery-free readiness.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="conclusion-cta">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-conclusion-cta" data-section-toggle data-section="conclusion-cta">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="conclusion-cta" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-conclusion-cta" type="button" aria-expanded="true" aria-controls="section-content-conclusion-cta" data-accordion-trigger data-section="conclusion-cta">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -850,264 +783,37 @@ Hotel first. That way you adjust before leaving. If you buy souvenirs, re-check 
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-conclusion-cta" data-collapsible>
-                <p>Frequent flyers need gear that works every single time. A <strong>durable luggage scale</strong> keeps you inside airline limits, avoids last-minute shuffles on the terminal floor, and pays for itself the first time you skip an overweight fee. Choose solid hardware, a readable display, and the right features—then make weighing your quickest pre-flight habit.</p>
+              <div class="post-section__panel" id="section-content-conclusion-cta" role="region" aria-labelledby="section-trigger-conclusion-cta" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Frequent flyers need gear that works every single time. A <strong>durable luggage scale</strong> keeps you inside airline limits, avoids last-minute shuffles on the terminal floor, and pays for itself the first time you skip an overweight fee. Choose solid hardware, a readable display, and the right features—then make weighing your quickest pre-flight habit.</p>
 <p><strong>Next step:</strong> Add a durable scale to your go-bag so you can fly confidently on every itinerary.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#introduction">Introduction</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-durability-matters-for-frequent-flyers">Why Durability Matters for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#how-a-handheld-luggage-scale-works-simple-breakdown">How a Handheld Luggage Scale Works (Simple Breakdown)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#key-benefits-for-frequent-flyers">Key Benefits for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#comparison-what-to-look-for">Comparison: What to Look For</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#use-cases-for-frequent-flyers">Use Cases for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips-best-practices">Pro Tips &amp; Best Practices</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#frequently-asked-questions-faq">Frequently Asked Questions (FAQ)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#final-checklist-buy-once-fly-often">Final Checklist (Buy Once, Fly Often)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#conclusion-cta">Conclusion &amp; CTA</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#introduction">Introduction</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-durability-matters-for-frequent-flyers">Why Durability Matters for Frequent Flyers</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#how-a-handheld-luggage-scale-works-simple-breakdown">How a Handheld Luggage Scale Works (Simple Breakdown)</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#key-benefits-for-frequent-flyers">Key Benefits for Frequent Flyers</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#comparison-what-to-look-for">Comparison: What to Look For</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#use-cases-for-frequent-flyers">Use Cases for Frequent Flyers</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips-best-practices">Pro Tips &amp; Best Practices</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#frequently-asked-questions-faq">Frequently Asked Questions (FAQ)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#final-checklist-buy-once-fly-often">Final Checklist (Buy Once, Fly Often)</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#conclusion-cta">Conclusion &amp; CTA</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,72 +249,26 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
-          
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#affiliate-picks">Affiliate picks</a>
+      <div class="post__content">
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
-          </div>
           
-
-          <div class="post__body">
-            
-            
-            <div class="post__intro">
-              <p>This is your <strong>first test post</strong> in the new blog system.</p>
+          <div class="post__intro">
+            <p>This is your <strong>first test post</strong> in the new blog system.</p>
 <ul>
 <li>Written in Markdown</li>
 <li>Stored in <code>/blog-src/posts/hello-world/index.md</code></li>
 <li>When built, it will publish to <code>/blog/hello-world/</code></li>
 </ul>
-            </div>
+          </div>
+          
+          <div class="post__sections" data-accordion>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="affiliate-picks">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-affiliate-picks" data-section-toggle data-section="affiliate-picks">
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="affiliate-picks" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-affiliate-picks" type="button" aria-expanded="true" aria-controls="section-content-affiliate-picks" data-accordion-trigger data-section="affiliate-picks">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -339,11 +293,13 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-affiliate-picks" data-collapsible>
-                <p>Want to try the gear we mention? Start with our go-to travel scale:</p>
+              <div class="post-section__panel" id="section-content-affiliate-picks" role="region" aria-labelledby="section-trigger-affiliate-picks" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Want to try the gear we mention? Start with our go-to travel scale:</p>
 <p><a href="https://www.amazon.com/dp/B0AUPATCH01?tag=luggagescale-20" rel="sponsored noopener noreferrer" target="_blank" data-affiliate="amazon" data-asin="B0AUPATCH01" title="uPatch Digital Hanging Luggage Scale">Shop the uPatch luggage scale on Amazon</a></p>
 <p>Need help staying organized? &lt;a href=&quot;https://www.amazon.com/dp/B0BCUBESET1?tag=luggagescale-20&quot; rel=&quot;sponsored noopener noreferrer&quot; target=&quot;_blank&quot; data-affiliate=&quot;amazon&quot; data-asin=&quot;B0BCUBESET1&quot; title=&quot;Compression Packing Cubes Set&quot;&gt;Compression packing cubes on Amazon&lt;/a&gt;</p>
 <p><small>As an Amazon Associate we earn from qualifying purchases.</small></p>
+                </div>
               </div>
             </section>
             
@@ -352,7 +308,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -386,113 +342,28 @@
 
             
             
-            
           </div>
-
-          
-        </div>
-
         
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#affiliate-picks">Affiliate picks</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
 
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#affiliate-picks">Affiliate picks</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
+        
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
+        
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
+        
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
+        
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/index.html
+++ b/blog/index.html
@@ -149,40 +149,6 @@
         
         <div class="post-card__body">
           <h2 class="post-card__title">
-            <a href="/blog/portable-luggage-scale/">Portable Luggage Scale – Blog Post</a>
-          </h2>
-          
-          <p class="post-meta">
-            
-            <span class="post-meta__author">AutoBot</span>
-            
-            
-            <span class="post-meta__separator" aria-hidden="true">•</span>
-            
-            
-            <time class="post-meta__date" datetime="2025-09-24">September 24, 2025</time>
-            
-          </p>
-          
-          
-          <p class="post-card__excerpt">Portable Luggage Scale description here.</p>
-          
-          <div class="post-card__actions">
-            <a class="btn outline post-card__cta" href="/blog/portable-luggage-scale/">Read the article</a>
-          </div>
-        </div>
-      </article>
-    </li>
-  
-    
-    
-    
-    
-    <li class="post-grid__item">
-      <article class="post-card">
-        
-        <div class="post-card__body">
-          <h2 class="post-card__title">
             <a href="/blog/digital-luggage-scale/">Digital Luggage Scale – Blog Post</a>
           </h2>
           
@@ -475,6 +441,40 @@
           
           <div class="post-card__actions">
             <a class="btn outline post-card__cta" href="/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">Read the article</a>
+          </div>
+        </div>
+      </article>
+    </li>
+  
+    
+    
+    
+    
+    <li class="post-grid__item">
+      <article class="post-card">
+        
+        <div class="post-card__body">
+          <h2 class="post-card__title">
+            <a href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</a>
+          </h2>
+          
+          <p class="post-meta">
+            
+            <span class="post-meta__author">uPatch Travel Team</span>
+            
+            
+            <span class="post-meta__separator" aria-hidden="true">•</span>
+            
+            
+            <time class="post-meta__date" datetime="2025-09-15">September 15, 2025</time>
+            
+          </p>
+          
+          
+          <p class="post-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
+          
+          <div class="post-card__actions">
+            <a class="btn outline post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article</a>
           </div>
         </div>
       </article>

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -149,40 +149,6 @@
         
         <div class="post-card__body">
           <h2 class="post-card__title">
-            <a href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments)</a>
-          </h2>
-          
-          <p class="post-meta">
-            
-            <span class="post-meta__author">uPatch Travel Team</span>
-            
-            
-            <span class="post-meta__separator" aria-hidden="true">•</span>
-            
-            
-            <time class="post-meta__date" datetime="2025-09-15">September 15, 2025</time>
-            
-          </p>
-          
-          
-          <p class="post-card__excerpt">Solve tricky gear weigh-ins with strap hacks and balance tips that keep bulky items within airline limits.</p>
-          
-          <div class="post-card__actions">
-            <a class="btn outline post-card__cta" href="/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">Read the article</a>
-          </div>
-        </div>
-      </article>
-    </li>
-  
-    
-    
-    
-    
-    <li class="post-grid__item">
-      <article class="post-card">
-        
-        <div class="post-card__body">
-          <h2 class="post-card__title">
             <a href="/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb</a>
           </h2>
           

--- a/blog/sitemap.xml
+++ b/blog/sitemap.xml
@@ -2,11 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   
   <url>
-    <loc>https://luggage-scale.com/blog/portable-luggage-scale/</loc>
-    <lastmod>2025-09-24</lastmod>
-  </url>
-  
-  <url>
     <loc>https://luggage-scale.com/blog/digital-luggage-scale/</loc>
     <lastmod>2025-09-23</lastmod>
   </url>
@@ -82,7 +77,7 @@
     <loc>https://luggage-scale.com/blog/</loc>
     <lastmod>
       
-        2025-09-24
+        2025-09-23
       
     </lastmod>
   </url>

--- a/blog/static/post.js
+++ b/blog/static/post.js
@@ -1,133 +1,203 @@
 (function () {
-  const sectionToggles = Array.from(document.querySelectorAll('[data-section-toggle]'));
-  const tocToggles = Array.from(document.querySelectorAll('.toc-item__toggle'));
-  const mobileTocToggle = document.querySelector('.post__toc-toggle');
-  const mobileTocPanel = document.querySelector('#post-toc-mobile');
-  const tocLinks = Array.from(document.querySelectorAll('.post__toc-nav a'));
-  const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const accordion = document.querySelector('[data-accordion]');
+  if (!accordion) return;
 
-  const prefersReducedMotion = () => reduceMotionQuery.matches;
+  const triggers = Array.from(
+    accordion.querySelectorAll('[data-accordion-trigger]')
+  );
+  if (!triggers.length) return;
 
-  const setContentHeight = (content, expanded) => {
-    if (!content) return;
-    if (prefersReducedMotion()) {
-      content.style.maxHeight = expanded ? 'none' : '0px';
-      content.dataset.open = expanded ? 'true' : 'false';
+  const reduceMotionQuery = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  );
+  const prefersReducedMotion = () =>
+    Boolean(reduceMotionQuery && reduceMotionQuery.matches);
+
+  const getPanel = (trigger) => {
+    const controls = trigger.getAttribute('aria-controls');
+    return controls ? document.getElementById(controls) : null;
+  };
+
+  const setExpanded = (trigger, expand, options = {}) => {
+    const panel = getPanel(trigger);
+    if (!panel) return;
+
+    const { immediate = false, force = false } = options;
+    const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
+    if (!force && wasExpanded === expand) {
       return;
     }
-    if (expanded) {
-      content.dataset.open = 'true';
-      content.style.maxHeight = content.scrollHeight + 'px';
-    } else {
-      content.dataset.open = 'false';
-      content.style.maxHeight = content.scrollHeight + 'px';
+
+    trigger.setAttribute('aria-expanded', expand ? 'true' : 'false');
+    trigger.classList.toggle('is-open', expand);
+
+    panel.dataset.open = expand ? 'true' : 'false';
+    panel.setAttribute('aria-hidden', expand ? 'false' : 'true');
+
+    const skipAnimation = immediate || prefersReducedMotion();
+
+    if (skipAnimation) {
+      panel.style.transitionDuration = '0ms';
+      panel.style.maxHeight = expand ? 'none' : '0px';
+      panel.style.opacity = expand ? '1' : '0';
       requestAnimationFrame(() => {
-        content.style.maxHeight = '0px';
+        panel.style.transitionDuration = '';
+      });
+      return;
+    }
+
+    if (expand) {
+      panel.style.maxHeight = panel.scrollHeight + 'px';
+      panel.style.opacity = '1';
+      const finalize = (event) => {
+        if (event.propertyName !== 'max-height') return;
+        if (panel.dataset.open === 'true') {
+          panel.style.maxHeight = 'none';
+        }
+        panel.removeEventListener('transitionend', finalize);
+      };
+      panel.addEventListener('transitionend', finalize);
+    } else {
+      if (panel.style.maxHeight === 'none' || !panel.style.maxHeight) {
+        panel.style.maxHeight = panel.scrollHeight + 'px';
+      }
+      panel.style.opacity = '0';
+      requestAnimationFrame(() => {
+        panel.style.maxHeight = '0px';
       });
     }
   };
 
-  const toggleSection = (toggle, force) => {
-    const contentId = toggle.getAttribute('aria-controls');
-    const content = contentId ? document.getElementById(contentId) : null;
-    if (!content) return;
-    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-    const shouldExpand = typeof force === 'boolean' ? force : !isExpanded;
-    toggle.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
-    toggle.classList.toggle('is-open', shouldExpand);
-    setContentHeight(content, shouldExpand);
-  };
-
-  const updateAllSectionHeights = () => {
-    sectionToggles.forEach((toggle) => {
-      const contentId = toggle.getAttribute('aria-controls');
-      const content = contentId ? document.getElementById(contentId) : null;
-      if (!content) return;
-      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-      if (prefersReducedMotion()) {
-        content.style.maxHeight = isExpanded ? 'none' : '0px';
-      } else if (isExpanded) {
-        content.style.maxHeight = content.scrollHeight + 'px';
-      }
+  const collapseAll = (exceptTrigger, options = {}) => {
+    triggers.forEach((trigger) => {
+      if (trigger === exceptTrigger) return;
+      setExpanded(trigger, false, { ...options, force: true });
     });
   };
 
-  sectionToggles.forEach((toggle) => {
-    const contentId = toggle.getAttribute('aria-controls');
-    const content = contentId ? document.getElementById(contentId) : null;
-    if (!content) return;
-    toggle.classList.add('is-open');
-    toggle.setAttribute('aria-expanded', 'true');
-    content.dataset.open = 'true';
-    if (!prefersReducedMotion()) {
-      content.style.maxHeight = content.scrollHeight + 'px';
+  const focusTriggerAt = (index) => {
+    if (!triggers.length) return;
+    const total = triggers.length;
+    const nextIndex = (index + total) % total;
+    const target = triggers[nextIndex];
+    if (target) {
+      target.focus();
     }
-    toggle.addEventListener('click', () => toggleSection(toggle));
-  });
-
-  let resizeTimeout;
-  window.addEventListener('resize', () => {
-    clearTimeout(resizeTimeout);
-    resizeTimeout = setTimeout(updateAllSectionHeights, 150);
-  });
-
-  tocToggles.forEach((button) => {
-    const targetId = button.getAttribute('aria-controls');
-    const target = targetId ? document.getElementById(targetId) : null;
-    if (!target) return;
-    button.addEventListener('click', () => {
-      const expanded = button.getAttribute('aria-expanded') === 'true';
-      const nextState = !expanded;
-      button.setAttribute('aria-expanded', nextState ? 'true' : 'false');
-      button.classList.toggle('is-open', nextState);
-      if (nextState) {
-        target.removeAttribute('hidden');
-      } else {
-        target.setAttribute('hidden', '');
-      }
-    });
-  });
-
-  const closeMobileToc = () => {
-    if (!mobileTocToggle || !mobileTocPanel) return;
-    mobileTocToggle.setAttribute('aria-expanded', 'false');
-    mobileTocToggle.classList.remove('is-open');
-    mobileTocPanel.setAttribute('hidden', '');
   };
 
-  if (mobileTocToggle && mobileTocPanel) {
-    mobileTocToggle.addEventListener('click', () => {
-      const expanded = mobileTocToggle.getAttribute('aria-expanded') === 'true';
-      const nextState = !expanded;
-      mobileTocToggle.setAttribute('aria-expanded', nextState ? 'true' : 'false');
-      mobileTocToggle.classList.toggle('is-open', nextState);
-      if (nextState) {
-        mobileTocPanel.removeAttribute('hidden');
-      } else {
-        mobileTocPanel.setAttribute('hidden', '');
-      }
-    });
+  const openFromHash = (hash, { scroll = false, immediate = false } = {}) => {
+    if (!hash) return false;
+    const targetId = hash.replace('#', '');
+    if (!targetId) return false;
+    const trigger = triggers.find((btn) => btn.dataset.section === targetId);
+    if (!trigger) return false;
 
-    window.addEventListener('resize', () => {
-      if (window.innerWidth >= 900) {
-        closeMobileToc();
-      }
-    });
-  }
+    collapseAll(trigger, { immediate });
+    setExpanded(trigger, true, { immediate, force: true });
 
-  tocLinks.forEach((link) => {
-    link.addEventListener('click', () => {
-      const targetId = link.hash ? link.hash.slice(1) : '';
-      if (targetId) {
-        const matchingToggle = sectionToggles.find((btn) => btn.dataset.section === targetId);
-        if (matchingToggle) {
-          const isExpanded = matchingToggle.getAttribute('aria-expanded') === 'true';
-          if (!isExpanded) {
-            toggleSection(matchingToggle, true);
-          }
+    if (scroll) {
+      const heading = document.getElementById(targetId);
+      if (heading) {
+        const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+        heading.scrollIntoView({ behavior, block: 'start' });
+      }
+    }
+
+    return true;
+  };
+
+  const handleToggle = (trigger) => {
+    const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+    const nextState = !isExpanded;
+    if (nextState) {
+      collapseAll(trigger);
+    }
+    setExpanded(trigger, nextState, { force: true });
+  };
+
+  const handleKeyDown = (event) => {
+    const { key } = event;
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(key)) return;
+
+    event.preventDefault();
+    const index = triggers.indexOf(event.currentTarget);
+    if (index < 0) return;
+
+    if (key === 'ArrowDown') {
+      focusTriggerAt(index + 1);
+    } else if (key === 'ArrowUp') {
+      focusTriggerAt(index - 1);
+    } else if (key === 'Home') {
+      focusTriggerAt(0);
+    } else if (key === 'End') {
+      focusTriggerAt(triggers.length - 1);
+    }
+  };
+
+  const updateExpandedHeights = () => {
+    triggers.forEach((trigger) => {
+      const panel = getPanel(trigger);
+      if (!panel) return;
+      const expanded = trigger.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        if (prefersReducedMotion()) {
+          panel.style.maxHeight = 'none';
+        } else {
+          panel.style.maxHeight = panel.scrollHeight + 'px';
+          requestAnimationFrame(() => {
+            if (panel.dataset.open === 'true') {
+              panel.style.maxHeight = 'none';
+            }
+          });
         }
       }
-      closeMobileToc();
     });
+  };
+
+  triggers.forEach((trigger) => {
+    const panel = getPanel(trigger);
+    if (!panel) return;
+    panel.dataset.open = 'true';
+    panel.setAttribute('aria-hidden', 'false');
+
+    trigger.addEventListener('click', () => handleToggle(trigger));
+    trigger.addEventListener('keydown', handleKeyDown);
+
+    panel.addEventListener('transitionend', (event) => {
+      if (event.propertyName !== 'max-height') return;
+      if (panel.dataset.open === 'true' && !prefersReducedMotion()) {
+        panel.style.maxHeight = 'none';
+      }
+    });
+  });
+
+  window.addEventListener('resize', () => {
+    window.requestAnimationFrame(updateExpandedHeights);
+  });
+
+  const handleMotionChange = () => {
+    triggers.forEach((trigger) => {
+      const expanded = trigger.getAttribute('aria-expanded') === 'true';
+      setExpanded(trigger, expanded, { immediate: true, force: true });
+    });
+  };
+
+  if (reduceMotionQuery) {
+    if (typeof reduceMotionQuery.addEventListener === 'function') {
+      reduceMotionQuery.addEventListener('change', handleMotionChange);
+    } else if (typeof reduceMotionQuery.addListener === 'function') {
+      reduceMotionQuery.addListener(handleMotionChange);
+    }
+  }
+
+  requestAnimationFrame(() => {
+    triggers.forEach((trigger) => {
+      setExpanded(trigger, false, { immediate: true, force: true });
+    });
+    openFromHash(window.location.hash, { immediate: true, scroll: true });
+  });
+
+  window.addEventListener('hashchange', () => {
+    openFromHash(window.location.hash, { scroll: true });
   });
 })();

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -1,24 +1,33 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
 
 :root {
-  --color-base: #0f172a;
-  --color-text: #1f2937;
-  --color-muted: #64748b;
-  --color-muted-soft: #94a3b8;
-  --color-surface: #f8fafc;
-  --color-card: #ffffff;
-  --color-accent: #2563eb;
-  --color-accent-strong: #1d4ed8;
+  --brand: #0056B3;
+  --text: #333333;
+  --bg-1: #FFFFFF;
+  --bg-2: #F7F9FC;
+  --accent-teal: #009688;
+  --accent-green: #28A745;
+  --accent-orange: #FF9800;
+  --accent-purple: #673AB7;
+  --color-base: #10213F;
+  --color-text: var(--text);
+  --color-muted: #5a667a;
+  --color-muted-soft: #8d99ad;
+  --color-surface: var(--bg-2);
+  --color-card: var(--bg-1);
+  --color-accent: var(--brand);
+  --color-accent-strong: #00448f;
   --color-secondary: #f97316;
-  --color-border: #e2e8f0;
-  --color-border-strong: #cbd5f5;
-  --shadow-card: 0 18px 45px rgba(15, 23, 42, 0.12);
-  --shadow-soft: 0 8px 24px rgba(15, 23, 42, 0.08);
-  --radius-card: 1.25rem;
+  --color-border: #d6e1f2;
+  --color-border-strong: #b7c9e6;
+  --shadow-card: 0 24px 50px rgba(16, 33, 63, 0.08);
+  --shadow-soft: 0 12px 32px rgba(16, 33, 63, 0.08);
+  --shadow-accordion: 0 2px 6px rgba(0, 0, 0, 0.08);
+  --radius-card: 1rem;
   --radius-pill: 999px;
-  --max-site-width: 72rem;
-  --max-content-width: 46rem;
-  --transition-fast: 200ms ease;
+  --max-site-width: 65rem;
+  --max-content-width: 48rem;
+  --transition-fast: 180ms ease;
   --transition-slow: 320ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -542,22 +551,24 @@ main.container {
 
 .post {
   background: var(--color-card);
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: calc(var(--radius-card) + 0.25rem);
   box-shadow: var(--shadow-card);
-  padding: clamp(2rem, 1.6rem + 1.5vw, 3.5rem);
-  max-width: calc(var(--max-content-width) + 22rem);
+  padding: clamp(2rem, 1.4rem + 1.2vw, 3rem);
   margin: 0 auto;
+  max-width: var(--max-site-width);
+  display: grid;
+  gap: 1.5rem;
 }
 
 .post__header {
-  padding-bottom: 1.75rem;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-  margin-bottom: 2.5rem;
+  display: grid;
+  gap: 0.75rem;
+  padding-bottom: 1.5rem;
+  border-bottom: none;
 }
 
 .post__title {
-  margin-bottom: 0.75rem;
+  margin: 0;
 }
 
 .post__excerpt {
@@ -566,56 +577,77 @@ main.container {
   font-size: 1.05rem;
 }
 
-.post__content-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 2.75rem;
-}
-
-.post__content-column {
-  max-width: var(--max-content-width);
-  width: 100%;
-}
-
-.post__intro {
-  margin-bottom: 2.5rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(37, 99, 235, 0.18);
-  background: rgba(37, 99, 235, 0.08);
-  color: var(--color-muted);
-}
-
-.post__body > * {
-  margin-top: 0;
-}
-
-.post__body > * + * {
-  margin-top: 1.75rem;
-}
-
-.post__body ul,
-.post__body ol {
-  padding-left: 1.5rem;
-}
-
-.post__body-content {
+.post__content {
   display: grid;
   gap: 1.75rem;
 }
 
+.post__intro {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.85rem;
+  border-left: 4px solid var(--brand);
+  background: linear-gradient(135deg, rgba(0, 86, 179, 0.12), rgba(0, 86, 179, 0.05));
+  color: var(--color-muted);
+  box-shadow: 0 6px 20px rgba(16, 33, 63, 0.08);
+}
+
+.post__sections {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.post__body-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
 .post-section {
-  padding-top: 1.75rem;
-  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  --section-accent: var(--brand);
+  --section-accent-muted: rgba(0, 86, 179, 0.12);
+  --section-accent-strong: rgba(0, 86, 179, 0.22);
+  --section-accent-icon-bg: rgba(0, 86, 179, 0.18);
+  background: var(--bg-1);
+  border-radius: 0.75rem;
+  box-shadow: var(--shadow-accordion);
+  border: 1px solid rgba(16, 33, 63, 0.05);
+  overflow: hidden;
 }
 
-.post-section:first-of-type {
-  border-top: none;
-  padding-top: 0;
+.post-section:nth-of-type(even) {
+  background: var(--bg-2);
 }
 
-.post-section__title {
-  margin: 0 0 0.75rem;
+.post-section[data-accent="teal"] {
+  --section-accent: var(--accent-teal);
+  --section-accent-muted: rgba(0, 150, 136, 0.12);
+  --section-accent-strong: rgba(0, 150, 136, 0.22);
+  --section-accent-icon-bg: rgba(0, 150, 136, 0.18);
+}
+
+.post-section[data-accent="green"] {
+  --section-accent: var(--accent-green);
+  --section-accent-muted: rgba(40, 167, 69, 0.12);
+  --section-accent-strong: rgba(40, 167, 69, 0.22);
+  --section-accent-icon-bg: rgba(40, 167, 69, 0.18);
+}
+
+.post-section[data-accent="orange"] {
+  --section-accent: var(--accent-orange);
+  --section-accent-muted: rgba(255, 152, 0, 0.14);
+  --section-accent-strong: rgba(255, 152, 0, 0.26);
+  --section-accent-icon-bg: rgba(255, 152, 0, 0.2);
+}
+
+.post-section[data-accent="purple"] {
+  --section-accent: var(--accent-purple);
+  --section-accent-muted: rgba(103, 58, 183, 0.14);
+  --section-accent-strong: rgba(103, 58, 183, 0.26);
+  --section-accent-icon-bg: rgba(103, 58, 183, 0.2);
+}
+
+.post-section__heading {
+  margin: 0;
 }
 
 .post-section__toggle {
@@ -623,252 +655,109 @@ main.container {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: calc(var(--radius-card) - 0.6rem);
-  border: 1px solid transparent;
-  background: rgba(37, 99, 235, 0.05);
+  gap: 1rem;
+  padding: 1.1rem 1.5rem;
+  min-height: 44px;
+  border: none;
+  background: var(--section-accent-muted);
   color: var(--color-base);
   font-size: 1.1rem;
   font-weight: 600;
   text-align: left;
   cursor: pointer;
-  transition: background var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .post-section__toggle:hover,
 .post-section__toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.12);
-  border-color: rgba(37, 99, 235, 0.3);
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  background: var(--section-accent-strong);
+  box-shadow: 0 8px 18px rgba(16, 33, 63, 0.12);
+}
+
+.post-section__toggle:focus-visible {
+  outline: 3px solid rgba(0, 86, 179, 0.35);
+  outline-offset: 2px;
 }
 
 .post-section__toggle[aria-expanded="true"] {
-  background: rgba(37, 99, 235, 0.09);
-  border-color: rgba(37, 99, 235, 0.24);
+  background: var(--section-accent-strong);
 }
 
 .post-section__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 0.75rem;
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--color-accent-strong);
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.9rem;
+  background: var(--section-accent-icon-bg);
+  color: var(--section-accent);
   flex-shrink: 0;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
 }
 
 .post-section__icon-svg {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: currentColor;
 }
 
 .post-section__label {
   flex: 1;
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
 }
 
 .post-section__chevron svg {
   width: 1rem;
   height: 1rem;
-  transition: transform var(--transition-fast);
-  color: var(--color-accent);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+  color: var(--section-accent);
+}
+
+.post-section__toggle:hover .post-section__icon,
+.post-section__toggle[aria-expanded="true"] .post-section__icon {
+  color: var(--section-accent);
+  background: rgba(255, 255, 255, 0.85);
 }
 
 .post-section__toggle[aria-expanded="true"] .post-section__chevron svg {
   transform: rotate(180deg);
 }
 
-.post-section__content {
-  margin-top: 1.25rem;
+.post-section__panel {
   overflow: hidden;
-  transition: max-height var(--transition-slow), opacity var(--transition-slow);
-}
-
-.post-section__content[data-open="false"] {
-  opacity: 0;
-}
-
-.post-section__content[data-open="true"] {
+  transition: max-height var(--transition-slow), opacity 220ms ease;
+  max-height: none;
   opacity: 1;
 }
 
-.post__toc {
-  display: none;
+.post-section__panel[data-open="false"] {
+  opacity: 0;
+  pointer-events: none;
 }
 
-.post__toc-inner {
-  background: var(--color-card);
-  border-radius: var(--radius-card);
-  padding: 1.75rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: var(--shadow-soft);
-  display: grid;
-  gap: 1.25rem;
+.post-section__panel-inner {
+  padding: 1.5rem 1.5rem 1.75rem;
 }
 
-.post__toc-title {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  font-size: 1.05rem;
-  color: var(--color-base);
+.post-section__panel-inner > *:first-child {
+  margin-top: 0;
 }
 
-.post__toc-title-icon svg {
-  width: 1.35rem;
-  height: 1.35rem;
-  color: var(--color-accent);
+.post-section__panel-inner > *:last-child {
+  margin-bottom: 0;
 }
 
-.post__toc-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.toc-item {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.toc-item__row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.toc-item__link {
-  color: var(--color-base);
-  text-decoration: none;
-  font-weight: 600;
-  line-height: 1.35;
-}
-
-.toc-item__link:hover,
-.toc-item__link:focus {
-  color: var(--color-accent-strong);
-}
-
-.toc-item__toggle {
-  border: none;
-  border-radius: 999px;
-  width: 2rem;
-  height: 2rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--color-accent);
-  cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
-}
-
-.toc-item__toggle:hover,
-.toc-item__toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.22);
-  color: var(--color-accent-strong);
-}
-
-.toc-item__toggle svg {
-  width: 0.85rem;
-  height: 0.85rem;
-  transition: transform var(--transition-fast);
-}
-
-.toc-item__toggle.is-open svg,
-.toc-item__toggle[aria-expanded="true"] svg {
-  transform: rotate(180deg);
-}
-
-.toc-sublist {
-  list-style: none;
-  margin: 0;
-  padding: 0 0 0 1.4rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.toc-sublist__link {
-  color: var(--color-muted);
-  text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.toc-sublist__link:hover,
-.toc-sublist__link:focus {
-  color: var(--color-accent);
-}
-
-.post__toc-mobile {
-  display: block;
-}
-
-.post__toc-toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.85rem 1.1rem;
-  border-radius: var(--radius-pill);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: var(--color-card);
-  font-weight: 600;
-  cursor: pointer;
-  color: var(--color-base);
-  box-shadow: var(--shadow-soft);
-  transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.post__toc-toggle:hover,
-.post__toc-toggle:focus-visible {
-  background: rgba(37, 99, 235, 0.08);
-  border-color: rgba(37, 99, 235, 0.2);
-}
-
-.post__toc-toggle.is-open,
-.post__toc-toggle[aria-expanded="true"] {
-  border-color: rgba(37, 99, 235, 0.32);
-  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.18);
-}
-
-.post__toc-toggle-icon svg,
-.post__toc-toggle-chevron svg {
-  width: 1.1rem;
-  height: 1.1rem;
-  color: var(--color-accent);
-  transition: transform var(--transition-fast);
-}
-
-.post__toc-toggle[aria-expanded="true"] .post__toc-toggle-chevron svg {
-  transform: rotate(180deg);
-}
-
-.post__toc-panel {
-  margin-top: 1rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: var(--radius-card);
-  background: var(--color-card);
-  padding: 1.25rem 1.5rem;
-  box-shadow: var(--shadow-soft);
-}
 
 .post__disclaimer {
-  margin-top: 2.75rem;
-  padding: 1.25rem 1.5rem;
-  background: rgba(15, 23, 42, 0.04);
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  font-size: 0.95rem;
+  margin: 0;
+  padding: 1rem 1.25rem;
+  background: rgba(16, 33, 63, 0.05);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(16, 33, 63, 0.08);
+  font-size: 0.9375rem;
   color: var(--color-muted);
 }
 
@@ -897,56 +786,56 @@ main.container {
 }
 
 .affiliate-card {
-  margin: 2.75rem 0;
-  padding: clamp(1.5rem, 1.2rem + 1vw, 2rem);
-  border-radius: var(--radius-card);
-  border: 1px solid rgba(37, 99, 235, 0.2);
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(249, 250, 255, 0.95));
-  box-shadow: var(--shadow-soft);
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(0, 86, 179, 0.18);
+  background: linear-gradient(135deg, rgba(0, 86, 179, 0.12), rgba(0, 86, 179, 0.04));
+  box-shadow: 0 12px 28px rgba(0, 86, 179, 0.12);
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .affiliate-card__media {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .affiliate-card__media img {
-  width: 100%;
-  max-width: 120px;
-  height: auto;
-  border-radius: calc(var(--radius-card) - 0.75rem);
+  width: 96px;
+  height: 96px;
+  object-fit: contain;
+  border-radius: 0.75rem;
 }
 
 .affiliate-card__icon {
-  width: 110px;
-  height: 110px;
-  border-radius: var(--radius-card);
-  background: rgba(37, 99, 235, 0.14);
+  width: 88px;
+  height: 88px;
+  border-radius: 0.75rem;
+  background: rgba(0, 86, 179, 0.18);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-accent);
+  color: var(--brand);
 }
 
 .affiliate-card__body {
   display: grid;
-  gap: 0.9rem;
+  gap: 0.75rem;
 }
 
 .affiliate-card__eyebrow {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--color-accent-strong);
+  color: var(--brand);
   font-weight: 700;
 }
 
 .affiliate-card__title {
   margin: 0;
-  font-size: clamp(1.35rem, 1.2rem + 0.4vw, 1.65rem);
+  font-size: clamp(1.25rem, 1.15rem + 0.3vw, 1.5rem);
   color: var(--color-base);
 }
 
@@ -958,12 +847,12 @@ main.container {
 .affiliate-card__actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .affiliate-card__disclaimer {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
   color: var(--color-muted-soft);
 }
 
@@ -981,116 +870,44 @@ main.container {
   color: var(--color-muted);
 }
 
-.site-footer {
-  background: var(--color-base);
-  color: #f8fafc;
-  padding: 3.5rem 0;
-  margin-top: 4rem;
+.legal-footer {
+  background: var(--bg-2);
+  padding: 2rem 0;
+  margin-top: 3rem;
+  border-top: 1px solid rgba(16, 33, 63, 0.08);
 }
 
-.site-footer__container {
-  display: grid;
-  gap: 2.5rem;
-  align-items: start;
-}
-
-.site-footer__brand {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.site-footer__logo {
-  font-size: 1.45rem;
-  font-weight: 700;
-  color: #f8fafc;
-  text-decoration: none;
-}
-
-.site-footer__summary {
-  margin: 0;
-  color: rgba(226, 232, 240, 0.85);
-  max-width: 30rem;
-}
-
-.site-footer__copyright {
-  margin: 0;
-  color: rgba(148, 163, 184, 0.85);
-  font-size: 0.95rem;
-}
-
-.site-footer__title {
-  margin: 0 0 1rem;
-  font-size: 1.05rem;
+.legal-footer__container {
   display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  color: #f8fafc;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
-.site-footer__title-icon svg {
-  width: 1.1rem;
-  height: 1.1rem;
-  color: rgba(148, 197, 255, 0.85);
-}
-
-.site-footer__links {
-  list-style: none;
+.legal-footer__brand {
   margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
 }
 
-.site-footer__link-item a {
-  color: rgba(226, 232, 240, 0.95);
-  text-decoration: none;
+.legal-footer__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+}
+
+.legal-footer__link {
+  color: var(--brand);
   font-weight: 600;
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 0.1rem;
 }
 
-.site-footer__link-item a:hover,
-.site-footer__link-item a:focus {
-  color: rgba(148, 197, 255, 0.98);
-}
-
-.site-footer__toc .post__toc-list {
-  gap: 0.6rem;
-}
-
-.site-footer__toc .toc-item__link {
-  color: rgba(226, 232, 240, 0.95);
-}
-
-.site-footer__toc .toc-item__link:hover,
-.site-footer__toc .toc-item__link:focus {
-  color: rgba(148, 197, 255, 0.98);
-}
-
-.site-footer__toc .toc-item__toggle {
-  background: rgba(255, 255, 255, 0.12);
-  color: #f8fafc;
-}
-
-.site-footer__toc .toc-item__toggle:hover,
-.site-footer__toc .toc-item__toggle:focus-visible {
-  background: rgba(255, 255, 255, 0.22);
-}
-
-.site-footer__toc .toc-sublist__link {
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.site-footer__toc .toc-sublist__link:hover,
-.site-footer__toc .toc-sublist__link:focus {
-  color: rgba(148, 197, 255, 0.98);
-}
-
-.site-footer__toc .toc-item__toggle svg,
-.site-footer__toc .post__toc-title-icon svg {
-  color: rgba(148, 197, 255, 0.85);
-}
-
-.site-footer__toc .post__toc-title {
-  color: #f8fafc;
+.legal-footer__link:hover,
+.legal-footer__link:focus {
+  color: var(--color-accent-strong);
+  text-decoration: underline;
 }
 
 .post-page .site-main {
@@ -1127,12 +944,15 @@ main.container {
   }
 
   .affiliate-card {
-    grid-template-columns: minmax(100px, 140px) 1fr;
+    grid-template-columns: auto 1fr;
     align-items: center;
+    gap: 1.5rem;
   }
 
-  .site-footer__container {
-    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  .legal-footer__container {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 }
 
@@ -1143,24 +963,7 @@ main.container {
   }
 
   .post {
-    padding: clamp(2.5rem, 2rem + 1vw, 3.5rem);
-  }
-
-  .post__content-grid {
-    display: grid;
-    grid-template-columns: minmax(0, var(--max-content-width)) minmax(16rem, 20rem);
-    gap: 3rem;
-    align-items: start;
-  }
-
-  .post__toc {
-    display: block;
-    position: sticky;
-    top: 7.5rem;
-  }
-
-  .post__toc-mobile {
-    display: none;
+    padding: clamp(2.25rem, 1.8rem + 1vw, 3.25rem);
   }
 }
 

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -131,12 +131,12 @@
   
   
   
-  
     
   
   
   
     
+  
   
   
   
@@ -249,99 +249,23 @@
         
       </header>
 
-      <div class="post__content-grid">
-        <div class="post__content-column">
+      <div class="post__content">
+        
           
-          <div class="post__toc-mobile">
-            <button class="post__toc-toggle" type="button" aria-expanded="false" aria-controls="post-toc-mobile">
-              <span class="post__toc-toggle-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span class="post__toc-toggle-label">On this page</span>
-              <span class="post__toc-toggle-chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-            </button>
-            <div class="post__toc-panel" id="post-toc-mobile" hidden>
-              <nav class="post__toc-nav" aria-label="On this page">
-                
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-              </nav>
-            </div>
+          <div class="post__intro">
+            <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
           </div>
           
-
-          <div class="post__body">
+          <div class="post__sections" data-accordion>
             
             
-            <div class="post__intro">
-              <p><em>Note:</em> Airline rules change—always double‑check your carrier’s current baggage policy before you go.</p>
-            </div>
             
-
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="why-it-matters">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-section-toggle data-section="why-it-matters">
+              
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -368,8 +292,10 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-why-it-matters" data-collapsible>
-                <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+              <div class="post-section__panel" id="section-content-why-it-matters" role="region" aria-labelledby="section-trigger-why-it-matters" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Using a luggage scale at home saves time, stress, and surprise fees. A quick weigh‑in the night before travel lets you repack calmly instead of scrambling at the airport.</p>
+                </div>
               </div>
             </section>
             
@@ -378,7 +304,7 @@
   <aside class="affiliate-card" data-affiliate-card>
     <div class="affiliate-card__media">
       
-      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async">
+      <img src="/blog/static/products/upatch-digital-scale.svg" alt="uPatch digital luggage scale" loading="lazy" decoding="async" width="160" height="160">
       
     </div>
     <div class="affiliate-card__body">
@@ -412,9 +338,12 @@
 
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="what-youll-need">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-section-toggle data-section="what-youll-need">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="what-youll-need" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-what-youll-need" type="button" aria-expanded="true" aria-controls="section-content-what-youll-need" data-accordion-trigger data-section="what-youll-need">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -439,19 +368,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-what-youll-need" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-what-youll-need" role="region" aria-labelledby="section-trigger-what-youll-need" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>uPatch battery‑free luggage scale</li>
 <li>Your packed bag</li>
 <li>Optional: a known‑weight item (like a 5 lb dumbbell) for quick verification</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="steps">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-steps" data-section-toggle data-section="steps">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="steps" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-steps" type="button" aria-expanded="true" aria-controls="section-content-steps" data-accordion-trigger data-section="steps">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -478,8 +412,9 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-steps" data-collapsible>
-                <ol>
+              <div class="post-section__panel" id="section-content-steps" role="region" aria-labelledby="section-trigger-steps" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ol>
 <li><strong>Zero the scale.</strong> For uPatch, give it a few firm shakes to power the display, then make sure it reads 0.0.</li>
 <li><strong>Clip securely.</strong> Attach the strap to the bag’s primary handle; confirm it’s centered.</li>
 <li><strong>Lift to full hang.</strong> Raise until the bag is fully off the ground—no dragging or touching.</li>
@@ -487,13 +422,17 @@
 <li><strong>Adjust and re‑check.</strong> If you’re close to the limit, move heavy items to a personal item or another suitcase and measure again.</li>
 <li><strong>Final verification.</strong> Repeat once to confirm. If the numbers differ by more than ~0.2–0.3 lb, re‑position and try again.</li>
 </ol>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="pro-tips">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-section-toggle data-section="pro-tips">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="pro-tips" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-pro-tips" type="button" aria-expanded="true" aria-controls="section-content-pro-tips" data-accordion-trigger data-section="pro-tips">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -519,19 +458,24 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-pro-tips" data-collapsible>
-                <ul>
+              <div class="post-section__panel" id="section-content-pro-tips" role="region" aria-labelledby="section-trigger-pro-tips" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <ul>
 <li>Weigh with travel‑day items inside (chargers, jackets).</li>
 <li>Airports can have different scales; aim 1–2 lb under your target.</li>
 <li>For odd shapes, use a short luggage strap to create a lifting loop.</li>
 </ul>
+                </div>
               </div>
             </section>
             
             
-            <section class="post-section" data-post-section>
-              <h2 class="post-section__title" id="after-you-weigh">
-                <button class="post-section__toggle" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-section-toggle data-section="after-you-weigh">
+            
+            
+            
+            <section class="post-section" data-post-section data-accent="brand">
+              <h2 class="post-section__heading" id="after-you-weigh" data-accordion-heading>
+                <button class="post-section__toggle" id="section-trigger-after-you-weigh" type="button" aria-expanded="true" aria-controls="section-content-after-you-weigh" data-accordion-trigger data-section="after-you-weigh">
                   <span class="post-section__icon" aria-hidden="true">
   
     
@@ -557,185 +501,38 @@
 </span>
                 </button>
               </h2>
-              <div class="post-section__content" id="section-content-after-you-weigh" data-collapsible>
-                <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
+              <div class="post-section__panel" id="section-content-after-you-weigh" role="region" aria-labelledby="section-trigger-after-you-weigh" data-accordion-panel data-open="true" aria-hidden="false">
+                <div class="post-section__panel-inner">
+                  <p>Snap a phone photo of the display for each bag. If an agent questions your weight, you’ll have a reference to discuss calmly.</p>
 <hr>
 <p>Want a quick refresher on using the uPatch luggage scale? See <a href="/manual.html">the Manual</a> or <a href="/shop.html">get a spare for family trips</a>.</p>
+                </div>
               </div>
             </section>
             
             
-            
           </div>
+        
 
-          
-        </div>
-
-        
-        <aside class="post__toc" aria-labelledby="on-this-page">
-          <div class="post__toc-inner">
-            <h2 id="on-this-page" class="post__toc-title">
-              <span class="post__toc-title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-              <span>On this page</span>
-            </h2>
-            <nav class="post__toc-nav" aria-label="On this page">
-              
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
-        
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
-        
-      </div>
-      
-    </li>
-    
-  </ol>
-
-            </nav>
-          </div>
-        </aside>
         
       </div>
     </article>
   </main>
 
-  <footer class="site-footer">
-    <div class="container site-footer__container">
-      <div class="site-footer__brand">
-        <a class="site-footer__logo" href="/blog/">Luggage Scale Blog</a>
-        <p class="site-footer__summary">Guides, tips, and insights about luggage scales, travel hacks, and smart packing.</p>
-        <p class="site-footer__copyright">© 2025 Luggage Scale Blog. All rights reserved.</p>
-      </div>
-      
-      <div class="site-footer__toc">
-        <h2 class="site-footer__title">
-          <span class="site-footer__title-icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <rect x="5" y="6" width="14" height="2" rx="1" fill="currentColor"/>
-      <rect x="5" y="11" width="9" height="2" rx="1" fill="currentColor" opacity="0.8"/>
-      <rect x="5" y="16" width="6" height="2" rx="1" fill="currentColor" opacity="0.6"/>
-    </svg>
-  
-</span>
-          <span>On this page</span>
-        </h2>
-        <nav class="site-footer__toc-nav" aria-label="Compact page outline">
-          
-  <ol class="post__toc-list">
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#why-it-matters">Why it matters</a>
+  <footer class="legal-footer">
+    <div class="container legal-footer__container">
+      <p class="legal-footer__brand">© 2025 Luggage Scale Blog</p>
+      <nav class="legal-footer__nav" aria-label="Legal links">
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#what-youll-need">What you’ll need</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/privacy">Privacy Policy</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#steps">Steps</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/terms">Terms of Service</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#pro-tips">Pro tips</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/affiliate-disclosure">Affiliate Disclosure</a>
         
-      </div>
-      
-    </li>
-    
-    <li class="toc-item">
-      <div class="toc-item__row">
-        <a class="toc-item__link" href="#after-you-weigh">After you weigh</a>
+        <a class="legal-footer__link" href="https://luggage-scale.com/contact">Contact</a>
         
-      </div>
-      
-    </li>
-    
-  </ol>
-
-        </nav>
-      </div>
-      
-      <div class="site-footer__legal">
-        <h2 class="site-footer__title">Legal &amp; Contact</h2>
-        <ul class="site-footer__links">
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/privacy">Privacy</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/terms">Terms</a>
-          </li>
-          
-          <li class="site-footer__link-item">
-            <a href="https://luggage-scale.com/contact">Contact</a>
-          </li>
-          
-          <li class="site-footer__link-item"><a href="/blog/">Blog index</a></li>
-          <li class="site-footer__link-item"><a href="/blog/sitemap.xml">Sitemap</a></li>
-        </ul>
-      </div>
+      </nav>
     </div>
   </footer>
   <script src="/blog/static/post.js" defer></script>


### PR DESCRIPTION
## Summary
- rebuild post layout markup into an accessible accordion with color-accented panels and a compact affiliate card slot after the first section
- refresh post styling with a brandable color system, alternating section backgrounds, reduced spacing, and a new legal links footer
- add a focused accordion controller script that supports single-open behavior, keyboard controls, deep linking, and reduced-motion users
- surface legal link targets and affiliate image metadata from configuration for consistent output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3564be24883328dd01893b880b02c