### PR TITLE
Refine blog accordion and FAQ layout

### DIFF
--- a/blog/portable-luggage-scale/index.html
+++ b/blog/portable-luggage-scale/index.html
@@ -257,7 +257,7 @@
             
             
             
-            <section class="post-section" data-post-section data-accent="brand">
+            <section class="post-section" data-post-section data-accent="brand" data-tone="why-it-matters">
               <h2 class="post-section__heading" id="introduction" data-accordion-heading>
                 <button class="post-section__toggle" id="section-trigger-introduction" type="button" aria-expanded="true" aria-controls="section-content-introduction" data-accordion-trigger data-section="introduction">
                   <span class="post-section__icon" aria-hidden="true">
@@ -337,7 +337,7 @@
             
               
             
-            <section class="post-section" data-post-section data-accent="brand">
+            <section class="post-section" data-post-section data-accent="brand" data-tone="faq">
               <h2 class="post-section__heading" id="why-it-matters" data-accordion-heading>
                 <button class="post-section__toggle" id="section-trigger-why-it-matters" type="button" aria-expanded="true" aria-controls="section-content-why-it-matters" data-accordion-trigger data-section="why-it-matters">
                   <span class="post-section__icon" aria-hidden="true">
@@ -394,8 +394,9 @@
             
               
             
-            <section class="post-section" data-post-section data-accent="teal">
+            <section class="post-section" data-post-section data-accent="teal" data-tone="how-it-works">
               <h2 class="post-section__heading" id="how-it-works" data-accordion-heading>
+                <span class="anchor-alias" id="how-it-works-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
                 <button class="post-section__toggle" id="section-trigger-how-it-works" type="button" aria-expanded="true" aria-controls="section-content-how-it-works" data-accordion-trigger data-section="how-it-works">
                   <span class="post-section__icon" aria-hidden="true">
   
@@ -424,47 +425,6 @@
                 </button>
               </h2>
               <div class="post-section__panel" id="section-content-how-it-works" role="region" aria-labelledby="section-trigger-how-it-works" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-              
-            
-            <section class="post-section" data-post-section data-accent="teal">
-              <h2 class="post-section__heading" id="how-it-works-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-how-it-works-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-how-it-works-portable-luggage-scale" data-accordion-trigger data-section="how-it-works-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">How It Works: Portable Luggage Scale</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-      <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-  
-</span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-how-it-works-portable-luggage-scale" role="region" aria-labelledby="section-trigger-how-it-works-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
                 <div class="post-section__panel-inner">
                   <p>A portable luggage scale is a handy device designed to help travelers avoid overweight baggage fees by allowing them to weigh their luggage before arriving at the airport. Here's an overview of how it works:</p>
 <h3 id="design-and-components">Design and Components</h3>
@@ -527,7 +487,7 @@
             
               
             
-            <section class="post-section" data-post-section data-accent="green">
+            <section class="post-section" data-post-section data-accent="green" data-tone="key-benefits">
               <h2 class="post-section__heading" id="key-benefits" data-accordion-heading>
                 <button class="post-section__toggle" id="section-trigger-key-benefits" type="button" aria-expanded="true" aria-controls="section-content-key-benefits" data-accordion-trigger data-section="key-benefits">
                   <span class="post-section__icon" aria-hidden="true">
@@ -602,7 +562,7 @@
             
               
             
-            <section class="post-section" data-post-section data-accent="orange">
+            <section class="post-section" data-post-section data-accent="orange" data-tone="comparison">
               <h2 class="post-section__heading" id="comparison" data-accordion-heading>
                 <button class="post-section__toggle" id="section-trigger-comparison" type="button" aria-expanded="true" aria-controls="section-content-comparison" data-accordion-trigger data-section="comparison">
                   <span class="post-section__icon" aria-hidden="true">
@@ -718,7 +678,7 @@
             
               
             
-            <section class="post-section" data-post-section data-accent="purple">
+            <section class="post-section" data-post-section data-accent="purple" data-tone="use-cases">
               <h2 class="post-section__heading" id="use-cases" data-accordion-heading>
                 <button class="post-section__toggle" id="section-trigger-use-cases" type="button" aria-expanded="true" aria-controls="section-content-use-cases" data-accordion-trigger data-section="use-cases">
                   <span class="post-section__icon" aria-hidden="true">
@@ -992,446 +952,280 @@
               </h2>
               <div class="post-section__panel" id="section-content-faq" role="region" aria-labelledby="section-trigger-faq" data-accordion-panel data-open="true" aria-hidden="false">
                 <div class="post-section__panel-inner">
-                  <h1>FAQ: Portable Luggage Scale</h1>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="what-is-a-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-what-is-a-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-what-is-a-portable-luggage-scale" data-accordion-trigger data-section="what-is-a-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">What is a portable luggage scale?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                  <div class="faq-accordion" data-faq-accordion>
+                    <h3 class="faq-accordion__title">FAQ: Portable Luggage Scale</h3>
+                    <div class="faq-accordion__list" role="list">
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-what-is-a-portable-luggage-scale" data-faq-aliases="what-is-a-portable-luggage-scale">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-what-is-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="what-is-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-what-is-a-portable-luggage-scale" aria-expanded="true" aria-controls="faq-panel-what-is-a-portable-luggage-scale" data-faq-trigger>
+                            <span class="faq-accordion__question">What is a portable luggage scale?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-what-is-a-portable-luggage-scale" role="region" aria-labelledby="section-trigger-what-is-a-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>A portable luggage scale is a compact weighing device designed to help travelers determine the weight of their luggage before checking it in at the airport or other travel venues. It typically features a hook or strap to attach to the bag, as well as a digital or analog display to show the weight.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="why-do-i-need-a-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-why-do-i-need-a-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-why-do-i-need-a-portable-luggage-scale" data-accordion-trigger data-section="why-do-i-need-a-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Why do I need a portable luggage scale?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-what-is-a-portable-luggage-scale" role="region" aria-labelledby="faq-trigger-what-is-a-portable-luggage-scale" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>A portable luggage scale is a compact weighing device designed to help travelers determine the weight of their luggage before checking it in at the airport or other travel venues. It typically features a hook or strap to attach to the bag, as well as a digital or analog display to show the weight.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-why-do-i-need-a-portable-luggage-scale" data-faq-aliases="why-do-i-need-a-portable-luggage-scale">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-why-do-i-need-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="why-do-i-need-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-why-do-i-need-a-portable-luggage-scale" aria-expanded="true" aria-controls="faq-panel-why-do-i-need-a-portable-luggage-scale" data-faq-trigger>
+                            <span class="faq-accordion__question">Why do I need a portable luggage scale?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-why-do-i-need-a-portable-luggage-scale" role="region" aria-labelledby="section-trigger-why-do-i-need-a-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Travelers often need a portable luggage scale to avoid overage fees from airlines, which charge for bags that exceed weight limits. A luggage scale helps you pack more efficiently and ensures you stay within the required weight limits, making your travel experience smoother and more cost-effective.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="how-does-a-portable-luggage-scale-work" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-how-does-a-portable-luggage-scale-work" type="button" aria-expanded="true" aria-controls="section-content-how-does-a-portable-luggage-scale-work" data-accordion-trigger data-section="how-does-a-portable-luggage-scale-work">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">How does a portable luggage scale work?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-why-do-i-need-a-portable-luggage-scale" role="region" aria-labelledby="faq-trigger-why-do-i-need-a-portable-luggage-scale" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Travelers often need a portable luggage scale to avoid overage fees from airlines, which charge for bags that exceed weight limits. A luggage scale helps you pack more efficiently and ensures you stay within the required weight limits, making your travel experience smoother and more cost-effective.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-how-does-a-portable-luggage-scale-work" data-faq-aliases="how-does-a-portable-luggage-scale-work">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-how-does-a-portable-luggage-scale-work" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="how-does-a-portable-luggage-scale-work" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-how-does-a-portable-luggage-scale-work" aria-expanded="true" aria-controls="faq-panel-how-does-a-portable-luggage-scale-work" data-faq-trigger>
+                            <span class="faq-accordion__question">How does a portable luggage scale work?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-how-does-a-portable-luggage-scale-work" role="region" aria-labelledby="section-trigger-how-does-a-portable-luggage-scale-work" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>To use a portable luggage scale, you typically:</p>
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-how-does-a-portable-luggage-scale-work" role="region" aria-labelledby="faq-trigger-how-does-a-portable-luggage-scale-work" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>To use a portable luggage scale, you typically:</p>
 <ol>
 <li>Attach the scale’s hook or strap to your bag's handle.</li>
 <li>Lift the bag off the ground, allowing the scale to measure the weight.</li>
 <li>Read the weight displayed on the scale’s screen. Many digital scales will automatically lock in the weight until you can set it down.</li>
 </ol>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" data-accordion-trigger data-section="what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">What is the maximum weight capacity of a portable luggage scale?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" data-faq-aliases="what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" aria-expanded="true" aria-controls="faq-panel-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" data-faq-trigger>
+                            <span class="faq-accordion__question">What is the maximum weight capacity of a portable luggage scale?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" role="region" aria-labelledby="section-trigger-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Most portable luggage scales have a weight capacity ranging from 50 to 110 pounds (approximately 23 to 50 kg). Always check the specifications of the individual scale to ensure it meets your needs.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="are-portable-luggage-scales-accurate" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-are-portable-luggage-scales-accurate" type="button" aria-expanded="true" aria-controls="section-content-are-portable-luggage-scales-accurate" data-accordion-trigger data-section="are-portable-luggage-scales-accurate">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Are portable luggage scales accurate?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" role="region" aria-labelledby="faq-trigger-what-is-the-maximum-weight-capacity-of-a-portable-luggage-scale" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Most portable luggage scales have a weight capacity ranging from 50 to 110 pounds (approximately 23 to 50 kg). Always check the specifications of the individual scale to ensure it meets your needs.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-are-portable-luggage-scales-accurate" data-faq-aliases="are-portable-luggage-scales-accurate">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-are-portable-luggage-scales-accurate" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="are-portable-luggage-scales-accurate" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-are-portable-luggage-scales-accurate" aria-expanded="true" aria-controls="faq-panel-are-portable-luggage-scales-accurate" data-faq-trigger>
+                            <span class="faq-accordion__question">Are portable luggage scales accurate?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-are-portable-luggage-scales-accurate" role="region" aria-labelledby="section-trigger-are-portable-luggage-scales-accurate" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Yes, most portable luggage scales are designed to provide accurate readings. However, the accuracy can vary based on the brand and model, so it's essential to select a reliable one and ensure it's calibrated correctly.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="do-portable-luggage-scales-require-batteries" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-do-portable-luggage-scales-require-batteries" type="button" aria-expanded="true" aria-controls="section-content-do-portable-luggage-scales-require-batteries" data-accordion-trigger data-section="do-portable-luggage-scales-require-batteries">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Do portable luggage scales require batteries?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-are-portable-luggage-scales-accurate" role="region" aria-labelledby="faq-trigger-are-portable-luggage-scales-accurate" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Yes, most portable luggage scales are designed to provide accurate readings. However, the accuracy can vary based on the brand and model, so it's essential to select a reliable one and ensure it's calibrated correctly.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-do-portable-luggage-scales-require-batteries" data-faq-aliases="do-portable-luggage-scales-require-batteries">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-do-portable-luggage-scales-require-batteries" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="do-portable-luggage-scales-require-batteries" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-do-portable-luggage-scales-require-batteries" aria-expanded="true" aria-controls="faq-panel-do-portable-luggage-scales-require-batteries" data-faq-trigger>
+                            <span class="faq-accordion__question">Do portable luggage scales require batteries?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-do-portable-luggage-scales-require-batteries" role="region" aria-labelledby="section-trigger-do-portable-luggage-scales-require-batteries" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Many portable luggage scales are powered by batteries, typically CR2032 or AAA types. Some models may also use rechargeable batteries or have a built-in USB charging option. Always check the specifics of the scale you are considering.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" type="button" aria-expanded="true" aria-controls="section-content-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" data-accordion-trigger data-section="can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Can I use a portable luggage scale on other items besides luggage?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-do-portable-luggage-scales-require-batteries" role="region" aria-labelledby="faq-trigger-do-portable-luggage-scales-require-batteries" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Many portable luggage scales are powered by batteries, typically CR2032 or AAA types. Some models may also use rechargeable batteries or have a built-in USB charging option. Always check the specifics of the scale you are considering.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" data-faq-aliases="can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" aria-expanded="true" aria-controls="faq-panel-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" data-faq-trigger>
+                            <span class="faq-accordion__question">Can I use a portable luggage scale on other items besides luggage?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" role="region" aria-labelledby="section-trigger-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Yes, portable luggage scales can be used to weigh other items, such as boxes, packages, or any other objects that can be safely lifted and supported by the scale.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="is-a-portable-luggage-scale-necessary-for-international-travel" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-is-a-portable-luggage-scale-necessary-for-international-travel" type="button" aria-expanded="true" aria-controls="section-content-is-a-portable-luggage-scale-necessary-for-international-travel" data-accordion-trigger data-section="is-a-portable-luggage-scale-necessary-for-international-travel">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Is a portable luggage scale necessary for international travel?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" role="region" aria-labelledby="faq-trigger-can-i-use-a-portable-luggage-scale-on-other-items-besides-luggage" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Yes, portable luggage scales can be used to weigh other items, such as boxes, packages, or any other objects that can be safely lifted and supported by the scale.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-is-a-portable-luggage-scale-necessary-for-international-travel" data-faq-aliases="is-a-portable-luggage-scale-necessary-for-international-travel">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-is-a-portable-luggage-scale-necessary-for-international-travel" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="is-a-portable-luggage-scale-necessary-for-international-travel" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-is-a-portable-luggage-scale-necessary-for-international-travel" aria-expanded="true" aria-controls="faq-panel-is-a-portable-luggage-scale-necessary-for-international-travel" data-faq-trigger>
+                            <span class="faq-accordion__question">Is a portable luggage scale necessary for international travel?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-is-a-portable-luggage-scale-necessary-for-international-travel" role="region" aria-labelledby="section-trigger-is-a-portable-luggage-scale-necessary-for-international-travel" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>While not strictly necessary, a portable luggage scale is highly recommended for international travel. Different airlines and countries may have varying weight limits, and it's easy to underestimate how much your luggage weighs after packing.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="how-do-i-maintain-and-care-for-my-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-how-do-i-maintain-and-care-for-my-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-how-do-i-maintain-and-care-for-my-portable-luggage-scale" data-accordion-trigger data-section="how-do-i-maintain-and-care-for-my-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">How do I maintain and care for my portable luggage scale?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-is-a-portable-luggage-scale-necessary-for-international-travel" role="region" aria-labelledby="faq-trigger-is-a-portable-luggage-scale-necessary-for-international-travel" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>While not strictly necessary, a portable luggage scale is highly recommended for international travel. Different airlines and countries may have varying weight limits, and it's easy to underestimate how much your luggage weighs after packing.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-how-do-i-maintain-and-care-for-my-portable-luggage-scale" data-faq-aliases="how-do-i-maintain-and-care-for-my-portable-luggage-scale">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-how-do-i-maintain-and-care-for-my-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="how-do-i-maintain-and-care-for-my-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-how-do-i-maintain-and-care-for-my-portable-luggage-scale" aria-expanded="true" aria-controls="faq-panel-how-do-i-maintain-and-care-for-my-portable-luggage-scale" data-faq-trigger>
+                            <span class="faq-accordion__question">How do I maintain and care for my portable luggage scale?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-how-do-i-maintain-and-care-for-my-portable-luggage-scale" role="region" aria-labelledby="section-trigger-how-do-i-maintain-and-care-for-my-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>To maintain your portable luggage scale:</p>
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-how-do-i-maintain-and-care-for-my-portable-luggage-scale" role="region" aria-labelledby="faq-trigger-how-do-i-maintain-and-care-for-my-portable-luggage-scale" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>To maintain your portable luggage scale:</p>
 <ul>
 <li>Store it in a safe, dry place to avoid moisture damage.</li>
 <li>Avoid overloading the scale beyond its maximum weight capacity to prevent damage.</li>
 <li>If it's battery-operated, replace the batteries as needed, and keep the terminals clean.</li>
 </ul>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" type="button" aria-expanded="true" aria-controls="section-content-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" data-accordion-trigger data-section="can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Can I take a portable luggage scale in my carry-on luggage?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" data-faq-aliases="can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" aria-expanded="true" aria-controls="faq-panel-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" data-faq-trigger>
+                            <span class="faq-accordion__question">Can I take a portable luggage scale in my carry-on luggage?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" role="region" aria-labelledby="section-trigger-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Yes, portable luggage scales are generally allowed in both carry-on and checked luggage. However, be sure to consult your airline’s regulations regarding electronic devices and batteries.</p>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="what-should-i-look-for-when-buying-a-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-what-should-i-look-for-when-buying-a-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-what-should-i-look-for-when-buying-a-portable-luggage-scale" data-accordion-trigger data-section="what-should-i-look-for-when-buying-a-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">What should I look for when buying a portable luggage scale?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" role="region" aria-labelledby="faq-trigger-can-i-take-a-portable-luggage-scale-in-my-carry-on-luggage" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Yes, portable luggage scales are generally allowed in both carry-on and checked luggage. However, be sure to consult your airline’s regulations regarding electronic devices and batteries.</p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-what-should-i-look-for-when-buying-a-portable-luggage-scale" data-faq-aliases="what-should-i-look-for-when-buying-a-portable-luggage-scale">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-what-should-i-look-for-when-buying-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="what-should-i-look-for-when-buying-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-what-should-i-look-for-when-buying-a-portable-luggage-scale" aria-expanded="true" aria-controls="faq-panel-what-should-i-look-for-when-buying-a-portable-luggage-scale" data-faq-trigger>
+                            <span class="faq-accordion__question">What should I look for when buying a portable luggage scale?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-what-should-i-look-for-when-buying-a-portable-luggage-scale" role="region" aria-labelledby="section-trigger-what-should-i-look-for-when-buying-a-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>When purchasing a portable luggage scale, consider the following features:</p>
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-what-should-i-look-for-when-buying-a-portable-luggage-scale" role="region" aria-labelledby="faq-trigger-what-should-i-look-for-when-buying-a-portable-luggage-scale" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>When purchasing a portable luggage scale, consider the following features:</p>
 <ul>
 <li>Maximum weight capacity: Ensure it meets your luggage needs.</li>
 <li>Accuracy: Look for scales with good reviews on accuracy.</li>
@@ -1439,54 +1233,44 @@
 <li>Portability: Compact design for easy storage.</li>
 <li>Durability: A build that can withstand travel conditions.</li>
 </ul>
-                </div>
-              </div>
-            </section>
-            
-            
-            
-            
-            
-            <section class="post-section" data-post-section data-accent="brand">
-              <h2 class="post-section__heading" id="where-can-i-buy-a-portable-luggage-scale" data-accordion-heading>
-                <button class="post-section__toggle" id="section-trigger-where-can-i-buy-a-portable-luggage-scale" type="button" aria-expanded="true" aria-controls="section-content-where-can-i-buy-a-portable-luggage-scale" data-accordion-trigger data-section="where-can-i-buy-a-portable-luggage-scale">
-                  <span class="post-section__icon" aria-hidden="true">
-  
-    
-  
-  
-    <svg class="icon post-section__icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 5h16l-2 6.5a6 6 0 0 1-12 0L4 5z" fill="currentColor" opacity="0.85"/>
-      <path d="M12 11a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4z" fill="currentColor"/>
-      <path d="M11 14h2v7h-2z" fill="currentColor"/>
-    </svg>
-  
-</span>
-                  <span class="post-section__label">Where can I buy a portable luggage scale?</span>
-                  <span class="post-section__chevron" aria-hidden="true">
-  
-    
-  
-  
+                          </div>
+                        </div>
+                      </div>
+                      <div class="faq-accordion__item" role="listitem" data-faq-item data-faq-id="faq-where-can-i-buy-a-portable-luggage-scale" data-faq-aliases="where-can-i-buy-a-portable-luggage-scale">
+                        <h3 class="faq-accordion__heading">
+                          <span class="anchor-alias" id="faq-where-can-i-buy-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <span class="anchor-alias" id="where-can-i-buy-a-portable-luggage-scale" aria-hidden="true" tabindex="-1"></span>
+                          <button class="faq-accordion__toggle" type="button" id="faq-trigger-where-can-i-buy-a-portable-luggage-scale" aria-expanded="true" aria-controls="faq-panel-where-can-i-buy-a-portable-luggage-scale" data-faq-trigger>
+                            <span class="faq-accordion__question">Where can I buy a portable luggage scale?</span>
+                            <span class="faq-accordion__chevron" aria-hidden="true">
+
+
+
+
     <svg class="icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
       <path d="M5 7l5 5 5-5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-  
+
 </span>
-                </button>
-              </h2>
-              <div class="post-section__panel" id="section-content-where-can-i-buy-a-portable-luggage-scale" role="region" aria-labelledby="section-trigger-where-can-i-buy-a-portable-luggage-scale" data-accordion-panel data-open="true" aria-hidden="false">
-                <div class="post-section__panel-inner">
-                  <p>Portable luggage scales are available at various retail outlets, including travel stores, electronics shops, and online platforms such as Amazon, eBay, or specialized travel websites.</p>
+                          </button>
+                        </h3>
+                        <div class="faq-accordion__panel" id="faq-panel-where-can-i-buy-a-portable-luggage-scale" role="region" aria-labelledby="faq-trigger-where-can-i-buy-a-portable-luggage-scale" data-faq-panel data-open="true" aria-hidden="false">
+                          <div class="faq-accordion__panel-inner">
+                            <p>Portable luggage scales are available at various retail outlets, including travel stores, electronics shops, and online platforms such as Amazon, eBay, or specialized travel websites.</p>
 <p>For any other inquiries regarding portable luggage scales, feel free to reach out!</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </section>
-            
-            
-            
-            
-            
+
+
+
+
+
             <section class="post-section" data-post-section data-accent="brand">
               <h2 class="post-section__heading" id="conclusion-cta" data-accordion-heading>
                 <button class="post-section__toggle" id="section-trigger-conclusion-cta" type="button" aria-expanded="true" aria-controls="section-content-conclusion-cta" data-accordion-trigger data-section="conclusion-cta">

--- a/blog/static/post.js
+++ b/blog/static/post.js
@@ -7,6 +7,10 @@
   );
   if (!triggers.length) return;
 
+  const sectionAliasMap = new Map([
+    ['how-it-works-portable-luggage-scale', 'how-it-works'],
+  ]);
+
   const reduceMotionQuery = window.matchMedia(
     '(prefers-reduced-motion: reduce)'
   );
@@ -85,25 +89,266 @@
     }
   };
 
-  const openFromHash = (hash, { scroll = false, immediate = false } = {}) => {
-    if (!hash) return false;
-    const targetId = hash.replace('#', '');
-    if (!targetId) return false;
-    const trigger = triggers.find((btn) => btn.dataset.section === targetId);
+  const createFaqAccordion = (container) => {
+    const items = Array.from(container.querySelectorAll('[data-faq-item]'));
+    if (!items.length) return null;
+
+    const faqTriggers = items
+      .map((item) => item.querySelector('[data-faq-trigger]'))
+      .filter(Boolean);
+
+    const aliasMap = new Map();
+    items.forEach((item) => {
+      const canonicalId = item.dataset.faqId;
+      if (!canonicalId) return;
+      aliasMap.set(canonicalId, canonicalId);
+      const aliases = (item.dataset.faqAliases || '')
+        .split(',')
+        .map((alias) => alias.trim())
+        .filter(Boolean);
+      aliases.forEach((alias) => aliasMap.set(alias, canonicalId));
+    });
+
+    const getPanel = (trigger) => {
+      const controls = trigger.getAttribute('aria-controls');
+      return controls ? document.getElementById(controls) : null;
+    };
+
+    const setFaqExpanded = (trigger, expand, options = {}) => {
+      const panel = getPanel(trigger);
+      if (!panel) return;
+
+      const { immediate = false, force = false } = options;
+      const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
+      if (!force && wasExpanded === expand) {
+        return;
+      }
+
+      trigger.setAttribute('aria-expanded', expand ? 'true' : 'false');
+
+      panel.dataset.open = expand ? 'true' : 'false';
+      panel.setAttribute('aria-hidden', expand ? 'false' : 'true');
+
+      const skipAnimation = immediate || prefersReducedMotion();
+
+      if (skipAnimation) {
+        panel.style.transitionDuration = '0ms';
+        panel.style.maxHeight = expand ? 'none' : '0px';
+        panel.style.opacity = expand ? '1' : '0';
+        requestAnimationFrame(() => {
+          panel.style.transitionDuration = '';
+        });
+        return;
+      }
+
+      if (expand) {
+        panel.style.maxHeight = panel.scrollHeight + 'px';
+        panel.style.opacity = '1';
+        const finalize = (event) => {
+          if (event.propertyName !== 'max-height') return;
+          if (panel.dataset.open === 'true') {
+            panel.style.maxHeight = 'none';
+          }
+          panel.removeEventListener('transitionend', finalize);
+        };
+        panel.addEventListener('transitionend', finalize);
+      } else {
+        if (panel.style.maxHeight === 'none' || !panel.style.maxHeight) {
+          panel.style.maxHeight = panel.scrollHeight + 'px';
+        }
+        panel.style.opacity = '0';
+        requestAnimationFrame(() => {
+          panel.style.maxHeight = '0px';
+        });
+      }
+    };
+
+    const focusFaqTriggerAt = (index) => {
+      if (!faqTriggers.length) return;
+      const total = faqTriggers.length;
+      const nextIndex = (index + total) % total;
+      const target = faqTriggers[nextIndex];
+      if (target) {
+        target.focus();
+      }
+    };
+
+    const handleFaqKeyDown = (event) => {
+      const { key } = event;
+      if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(key)) return;
+
+      event.preventDefault();
+      const index = faqTriggers.indexOf(event.currentTarget);
+      if (index < 0) return;
+
+      if (key === 'ArrowDown') {
+        focusFaqTriggerAt(index + 1);
+      } else if (key === 'ArrowUp') {
+        focusFaqTriggerAt(index - 1);
+      } else if (key === 'Home') {
+        focusFaqTriggerAt(0);
+      } else if (key === 'End') {
+        focusFaqTriggerAt(faqTriggers.length - 1);
+      }
+    };
+
+    faqTriggers.forEach((trigger) => {
+      const panel = getPanel(trigger);
+      if (!panel) return;
+
+      panel.dataset.open = 'true';
+      panel.setAttribute('aria-hidden', 'false');
+
+      trigger.addEventListener('click', () => {
+        const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+        setFaqExpanded(trigger, !isExpanded, { force: true });
+      });
+
+      trigger.addEventListener('keydown', handleFaqKeyDown);
+
+      panel.addEventListener('transitionend', (event) => {
+        if (event.propertyName !== 'max-height') return;
+        if (panel.dataset.open === 'true' && !prefersReducedMotion()) {
+          panel.style.maxHeight = 'none';
+        }
+      });
+    });
+
+    const updateExpandedHeights = () => {
+      faqTriggers.forEach((trigger) => {
+        const panel = getPanel(trigger);
+        if (!panel) return;
+        if (trigger.getAttribute('aria-expanded') === 'true') {
+          if (prefersReducedMotion()) {
+            panel.style.maxHeight = 'none';
+          } else {
+            panel.style.maxHeight = panel.scrollHeight + 'px';
+            requestAnimationFrame(() => {
+              if (panel.dataset.open === 'true') {
+                panel.style.maxHeight = 'none';
+              }
+            });
+          }
+        }
+      });
+    };
+
+    const handleMotionChange = () => {
+      faqTriggers.forEach((trigger) => {
+        const expanded = trigger.getAttribute('aria-expanded') === 'true';
+        setFaqExpanded(trigger, expanded, { immediate: true, force: true });
+      });
+    };
+
+    requestAnimationFrame(() => {
+      faqTriggers.forEach((trigger) => {
+        setFaqExpanded(trigger, false, { immediate: true, force: true });
+      });
+    });
+
+    const scrollToAnchor = (id) => {
+      const anchor = document.getElementById(id);
+      if (!anchor) return false;
+      const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+      anchor.scrollIntoView({ behavior, block: 'start' });
+      if (typeof anchor.focus === 'function') {
+        requestAnimationFrame(() => {
+          anchor.focus({ preventScroll: true });
+        });
+      }
+      return true;
+    };
+
+    const openFromHash = (
+      hashId,
+      { scroll = false, immediate = false, ensureSection } = {}
+    ) => {
+      const canonical = aliasMap.get(hashId);
+      if (!canonical) return false;
+      const trigger = faqTriggers.find((btn) => {
+        const item = btn.closest('[data-faq-item]');
+        return item && item.dataset.faqId === canonical;
+      });
+      if (!trigger) return false;
+
+      if (typeof ensureSection === 'function') {
+        ensureSection();
+      }
+
+      setFaqExpanded(trigger, true, { immediate, force: true });
+
+      if (scroll) {
+        if (!scrollToAnchor(hashId)) {
+          scrollToAnchor(canonical);
+        }
+      }
+
+      return true;
+    };
+
+    return {
+      isFaqHash: (id) => aliasMap.has(id),
+      openFromHash,
+      updateExpandedHeights,
+      handleMotionChange,
+    };
+  };
+
+  const faqContainer = accordion.querySelector('[data-faq-accordion]');
+  const faqController = faqContainer ? createFaqAccordion(faqContainer) : null;
+
+  const openSectionById = (
+    sectionId,
+    { scroll = false, immediate = false, focusId } = {}
+  ) => {
+    const trigger = triggers.find((btn) => btn.dataset.section === sectionId);
     if (!trigger) return false;
 
     collapseAll(trigger, { immediate });
     setExpanded(trigger, true, { immediate, force: true });
 
     if (scroll) {
-      const heading = document.getElementById(targetId);
-      if (heading) {
-        const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
-        heading.scrollIntoView({ behavior, block: 'start' });
+      const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+      const focusTargetId = focusId || null;
+      const targetElement =
+        (focusTargetId && document.getElementById(focusTargetId)) ||
+        document.getElementById(sectionId);
+
+      if (targetElement) {
+        targetElement.scrollIntoView({ behavior, block: 'start' });
+        if (focusTargetId && typeof targetElement.focus === 'function') {
+          requestAnimationFrame(() => {
+            targetElement.focus({ preventScroll: true });
+          });
+        }
       }
     }
 
     return true;
+  };
+
+  const openFromHash = (hash, { scroll = false, immediate = false } = {}) => {
+    if (!hash) return false;
+    const targetId = hash.replace('#', '');
+    if (!targetId) return false;
+
+    if (faqController && faqController.isFaqHash(targetId)) {
+      return faqController.openFromHash(targetId, {
+        scroll,
+        immediate,
+        ensureSection: () =>
+          openSectionById('faq', { immediate, scroll: false }),
+      });
+    }
+
+    const canonicalId = sectionAliasMap.get(targetId) || targetId;
+    const focusId = canonicalId !== targetId ? targetId : undefined;
+
+    return openSectionById(canonicalId, {
+      scroll,
+      immediate,
+      focusId,
+    });
   };
 
   const handleToggle = (trigger) => {
@@ -152,6 +397,9 @@
         }
       }
     });
+    if (faqController) {
+      faqController.updateExpandedHeights();
+    }
   };
 
   triggers.forEach((trigger) => {
@@ -180,6 +428,9 @@
       const expanded = trigger.getAttribute('aria-expanded') === 'true';
       setExpanded(trigger, expanded, { immediate: true, force: true });
     });
+    if (faqController) {
+      faqController.handleMotionChange();
+    }
   };
 
   if (reduceMotionQuery) {

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -603,47 +603,72 @@ main.container {
 }
 
 .post-section {
-  --section-accent: var(--brand);
-  --section-accent-muted: rgba(0, 86, 179, 0.12);
-  --section-accent-strong: rgba(0, 86, 179, 0.22);
-  --section-accent-icon-bg: rgba(0, 86, 179, 0.18);
-  background: var(--bg-1);
+  --section-bg: var(--color-card);
+  --section-bg-hover: #edf2fb;
+  --section-icon-color: var(--brand);
+  --section-icon-active: #00448f;
+  --section-icon-bg: rgba(0, 86, 179, 0.12);
+  --section-icon-active-bg: rgba(255, 255, 255, 0.85);
+  background: var(--section-bg);
   border-radius: 0.75rem;
   box-shadow: var(--shadow-accordion);
-  border: 1px solid rgba(16, 33, 63, 0.05);
+  border: none;
+  color: var(--text);
   overflow: hidden;
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.post-section:nth-of-type(even) {
-  background: var(--bg-2);
+.post-section:hover,
+.post-section:focus-within {
+  background: var(--section-bg-hover);
 }
 
-.post-section[data-accent="teal"] {
-  --section-accent: var(--accent-teal);
-  --section-accent-muted: rgba(0, 150, 136, 0.12);
-  --section-accent-strong: rgba(0, 150, 136, 0.22);
-  --section-accent-icon-bg: rgba(0, 150, 136, 0.18);
+.post-section[data-tone="why-it-matters"] {
+  --section-bg: #FDECEA;
+  --section-bg-hover: #E9D8D6;
+  --section-icon-color: #0056B3;
+  --section-icon-active: #004a9c;
+  --section-icon-bg: rgba(0, 86, 179, 0.16);
 }
 
-.post-section[data-accent="green"] {
-  --section-accent: var(--accent-green);
-  --section-accent-muted: rgba(40, 167, 69, 0.12);
-  --section-accent-strong: rgba(40, 167, 69, 0.22);
-  --section-accent-icon-bg: rgba(40, 167, 69, 0.18);
+.post-section[data-tone="how-it-works"] {
+  --section-bg: #EAF4FD;
+  --section-bg-hover: #D6E0E9;
+  --section-icon-color: #009688;
+  --section-icon-active: #00796b;
+  --section-icon-bg: rgba(0, 150, 136, 0.16);
 }
 
-.post-section[data-accent="orange"] {
-  --section-accent: var(--accent-orange);
-  --section-accent-muted: rgba(255, 152, 0, 0.14);
-  --section-accent-strong: rgba(255, 152, 0, 0.26);
-  --section-accent-icon-bg: rgba(255, 152, 0, 0.2);
+.post-section[data-tone="key-benefits"] {
+  --section-bg: #EAF9EA;
+  --section-bg-hover: #D6E5D6;
+  --section-icon-color: #28A745;
+  --section-icon-active: #1f8f39;
+  --section-icon-bg: rgba(40, 167, 69, 0.16);
 }
 
-.post-section[data-accent="purple"] {
-  --section-accent: var(--accent-purple);
-  --section-accent-muted: rgba(103, 58, 183, 0.14);
-  --section-accent-strong: rgba(103, 58, 183, 0.26);
-  --section-accent-icon-bg: rgba(103, 58, 183, 0.2);
+.post-section[data-tone="comparison"] {
+  --section-bg: #FFF8E6;
+  --section-bg-hover: #EBE4D2;
+  --section-icon-color: #FF9800;
+  --section-icon-active: #e08700;
+  --section-icon-bg: rgba(255, 152, 0, 0.18);
+}
+
+.post-section[data-tone="use-cases"] {
+  --section-bg: #F3E8FD;
+  --section-bg-hover: #DFD4E9;
+  --section-icon-color: #673AB7;
+  --section-icon-active: #5a32a2;
+  --section-icon-bg: rgba(103, 58, 183, 0.18);
+}
+
+.post-section[data-tone="faq"] {
+  --section-bg: #ECEFFD;
+  --section-bg-hover: #D8DBE9;
+  --section-icon-color: #3F51B5;
+  --section-icon-active: #3645a0;
+  --section-icon-bg: rgba(63, 81, 181, 0.18);
 }
 
 .post-section__heading {
@@ -659,28 +684,18 @@ main.container {
   padding: 1.1rem 1.5rem;
   min-height: 44px;
   border: none;
-  background: var(--section-accent-muted);
-  color: var(--color-base);
+  background: transparent;
+  color: inherit;
   font-size: 1.1rem;
   font-weight: 600;
   text-align: left;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.post-section__toggle:hover,
-.post-section__toggle:focus-visible {
-  background: var(--section-accent-strong);
-  box-shadow: 0 8px 18px rgba(16, 33, 63, 0.12);
+  transition: color var(--transition-fast), transform var(--transition-fast);
 }
 
 .post-section__toggle:focus-visible {
   outline: 3px solid rgba(0, 86, 179, 0.35);
   outline-offset: 2px;
-}
-
-.post-section__toggle[aria-expanded="true"] {
-  background: var(--section-accent-strong);
 }
 
 .post-section__icon {
@@ -690,8 +705,8 @@ main.container {
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 0.9rem;
-  background: var(--section-accent-icon-bg);
-  color: var(--section-accent);
+  background: var(--section-icon-bg);
+  color: var(--section-icon-color);
   flex-shrink: 0;
   transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
 }
@@ -713,13 +728,20 @@ main.container {
   width: 1rem;
   height: 1rem;
   transition: transform var(--transition-fast), color var(--transition-fast);
-  color: var(--section-accent);
+  color: var(--section-icon-color);
 }
 
 .post-section__toggle:hover .post-section__icon,
+.post-section__toggle:focus-visible .post-section__icon,
 .post-section__toggle[aria-expanded="true"] .post-section__icon {
-  color: var(--section-accent);
-  background: rgba(255, 255, 255, 0.85);
+  color: var(--section-icon-active);
+  background: var(--section-icon-active-bg);
+}
+
+.post-section__toggle:hover .post-section__chevron svg,
+.post-section__toggle:focus-visible .post-section__chevron svg,
+.post-section__toggle[aria-expanded="true"] .post-section__chevron svg {
+  color: var(--section-icon-active);
 }
 
 .post-section__toggle[aria-expanded="true"] .post-section__chevron svg {
@@ -747,6 +769,128 @@ main.container {
 }
 
 .post-section__panel-inner > *:last-child {
+  margin-bottom: 0;
+}
+
+.anchor-alias {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.faq-accordion {
+  --faq-accent: #3F51B5;
+  --faq-accent-strong: #3645a0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.faq-accordion__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-base);
+}
+
+.faq-accordion__list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.faq-accordion__item {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 0.65rem;
+  box-shadow: inset 0 0 0 1px rgba(63, 81, 181, 0.12);
+  overflow: hidden;
+}
+
+.faq-accordion__heading {
+  margin: 0;
+}
+
+.faq-accordion__toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  min-height: 44px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.faq-accordion__toggle:hover,
+.faq-accordion__toggle:focus-visible {
+  background: rgba(63, 81, 181, 0.12);
+}
+
+.faq-accordion__toggle:focus-visible {
+  outline: 3px solid rgba(63, 81, 181, 0.35);
+  outline-offset: 2px;
+}
+
+.faq-accordion__toggle[aria-expanded="true"] {
+  background: rgba(63, 81, 181, 0.12);
+}
+
+.faq-accordion__question {
+  flex: 1;
+}
+
+.faq-accordion__chevron svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  color: var(--faq-accent);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+}
+
+.faq-accordion__toggle:hover .faq-accordion__chevron svg,
+.faq-accordion__toggle:focus-visible .faq-accordion__chevron svg,
+.faq-accordion__toggle[aria-expanded="true"] .faq-accordion__chevron svg {
+  color: var(--faq-accent-strong);
+}
+
+.faq-accordion__toggle[aria-expanded="true"] .faq-accordion__chevron svg {
+  transform: rotate(180deg);
+}
+
+.faq-accordion__panel {
+  overflow: hidden;
+  transition: max-height var(--transition-slow), opacity 200ms ease;
+  max-height: none;
+  opacity: 1;
+  background: rgba(63, 81, 181, 0.06);
+}
+
+.faq-accordion__panel[data-open="false"] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.faq-accordion__panel-inner {
+  padding: 0.75rem 1.1rem 1.15rem;
+  color: var(--text);
+}
+
+.faq-accordion__panel-inner > *:first-child {
+  margin-top: 0;
+}
+
+.faq-accordion__panel-inner > *:last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- merge duplicate "How It Works" content into a single accordion panel and retain legacy anchors
- rebuild the FAQ into nested sub-accordions with hash navigation support for legacy IDs
- refresh card styling with tinted backgrounds and accessible hover states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d360e152dc833299786f6e940f7da7