### PR TITLE
Unify accordion styling, improve scroll behavior, and add favicon

### DIFF
--- a/blog-src/_includes/head.njk
+++ b/blog-src/_includes/head.njk
@@ -37,6 +37,8 @@
 <meta name="description" content="{{ computedMetaDescription }}">
 {% endif %}
 <link rel="canonical" href="{{ canonicalHref }}">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="{{ headSite.name }}">
 <meta property="og:title" content="{{ computedMetaTitle }}">

--- a/blog-src/static/post.js
+++ b/blog-src/static/post.js
@@ -16,24 +16,52 @@
   const getSectionElement = (trigger) =>
     trigger ? trigger.closest('[data-post-section]') : null;
 
-  const isElementTopInViewport = (element) => {
-    if (!element) return false;
-    const rect = element.getBoundingClientRect();
-    const viewportHeight =
-      window.innerHeight || document.documentElement.clientHeight || 0;
-    return rect.top >= 0 && rect.top <= viewportHeight;
+  const getPanelContent = (panel) =>
+    panel ? panel.querySelector('.post-section__panel-inner') || panel : null;
+
+  const getStickyHeaderOffset = () => {
+    const defaultHeight = 72;
+    const gap = 12;
+    const root = document.documentElement;
+    if (!root || typeof window.getComputedStyle !== 'function') {
+      return defaultHeight + gap;
+    }
+    const style = window.getComputedStyle(root);
+    if (!style) {
+      return defaultHeight + gap;
+    }
+    const parsed = parseFloat(style.getPropertyValue('--sticky-header-height'));
+    const headerHeight = Number.isNaN(parsed) ? defaultHeight : parsed;
+    return headerHeight + gap;
   };
 
-  const scrollSectionIntoView = (sectionEl, { behavior } = {}) => {
-    if (!sectionEl || typeof sectionEl.scrollIntoView !== 'function') {
+  const isContentTopFullyVisible = (element) => {
+    if (!element) return false;
+    const rect = element.getBoundingClientRect();
+    return rect.top >= getStickyHeaderOffset();
+  };
+
+  const scrollContentIntoView = (element, { behavior } = {}) => {
+    if (!element || typeof element.scrollIntoView !== 'function') {
       return;
     }
-    if (isElementTopInViewport(sectionEl)) {
+    if (isContentTopFullyVisible(element)) {
       return;
     }
     const scrollBehavior =
       behavior || (prefersReducedMotion() ? 'auto' : 'smooth');
-    sectionEl.scrollIntoView({ block: 'start', behavior: scrollBehavior });
+    element.scrollIntoView({ block: 'start', behavior: scrollBehavior });
+  };
+
+  const scheduleScrollToContent = (panel, options = {}) => {
+    const contentEl = getPanelContent(panel);
+    if (!contentEl) return;
+    const { behavior } = options;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        scrollContentIntoView(contentEl, { behavior });
+      });
+    });
   };
 
   const getPanel = (trigger) => {
@@ -43,7 +71,13 @@
 
   const setExpanded = (trigger, expand, options = {}) => {
     const panel = getPanel(trigger);
-    if (!panel) return;
+    const sectionElement = getSectionElement(trigger);
+    if (!panel) {
+      if (sectionElement) {
+        sectionElement.dataset.open = expand ? 'true' : 'false';
+      }
+      return;
+    }
 
     const { immediate = false, force = false } = options;
     const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
@@ -56,6 +90,9 @@
 
     panel.dataset.open = expand ? 'true' : 'false';
     panel.setAttribute('aria-hidden', expand ? 'false' : 'true');
+    if (sectionElement) {
+      sectionElement.dataset.open = expand ? 'true' : 'false';
+    }
 
     const skipAnimation = immediate || prefersReducedMotion();
 
@@ -116,13 +153,16 @@
     if (!trigger) return false;
 
     const sectionElement = getSectionElement(trigger);
+    const panel = getPanel(trigger);
     collapseAll(trigger, { immediate });
     setExpanded(trigger, true, { immediate, force: true });
 
     if (scroll) {
       const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
-      if (sectionElement) {
-        scrollSectionIntoView(sectionElement, { behavior });
+      if (panel) {
+        scheduleScrollToContent(panel, { behavior });
+      } else if (sectionElement) {
+        scrollContentIntoView(sectionElement, { behavior });
       } else {
         const heading = document.getElementById(targetId);
         if (heading && typeof heading.scrollIntoView === 'function') {
@@ -135,7 +175,6 @@
   };
 
   const handleToggle = (trigger) => {
-    const sectionElement = getSectionElement(trigger);
     const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
     const nextState = !isExpanded;
     if (nextState) {
@@ -143,7 +182,8 @@
     }
     setExpanded(trigger, nextState, { force: true });
     if (nextState) {
-      scrollSectionIntoView(sectionElement);
+      const panel = getPanel(trigger);
+      scheduleScrollToContent(panel);
     }
   };
 
@@ -191,6 +231,10 @@
     if (!panel) return;
     panel.dataset.open = 'true';
     panel.setAttribute('aria-hidden', 'false');
+    const sectionElement = getSectionElement(trigger);
+    if (sectionElement) {
+      sectionElement.dataset.open = 'true';
+    }
 
     trigger.addEventListener('click', () => handleToggle(trigger));
     trigger.addEventListener('keydown', handleKeyDown);

--- a/blog-src/static/style.css
+++ b/blog-src/static/style.css
@@ -615,48 +615,23 @@ main.container {
 }
 
 .post-section {
+  --card-bg: #EAF4FD;
+  --card-bg-hover: #D9ECFC;
   --section-accent: var(--brand);
-  --section-accent-muted: rgba(0, 86, 179, 0.12);
-  --section-accent-strong: rgba(0, 86, 179, 0.22);
+  --section-accent-muted: rgba(0, 86, 179, 0.18);
+  --section-accent-strong: rgba(0, 86, 179, 0.32);
   --section-accent-icon-bg: rgba(0, 86, 179, 0.18);
-  background: var(--bg-1);
+  background: var(--card-bg);
   border-radius: 0.75rem;
   box-shadow: var(--shadow-accordion);
   border: 1px solid rgba(16, 33, 63, 0.05);
   overflow: hidden;
-  scroll-margin-top: calc(var(--sticky-header-height, 72px) + 12px);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.post-section:nth-of-type(even) {
-  background: var(--bg-2);
-}
-
-.post-section[data-accent="teal"] {
-  --section-accent: var(--accent-teal);
-  --section-accent-muted: rgba(0, 150, 136, 0.12);
-  --section-accent-strong: rgba(0, 150, 136, 0.22);
-  --section-accent-icon-bg: rgba(0, 150, 136, 0.18);
-}
-
-.post-section[data-accent="green"] {
-  --section-accent: var(--accent-green);
-  --section-accent-muted: rgba(40, 167, 69, 0.12);
-  --section-accent-strong: rgba(40, 167, 69, 0.22);
-  --section-accent-icon-bg: rgba(40, 167, 69, 0.18);
-}
-
-.post-section[data-accent="orange"] {
-  --section-accent: var(--accent-orange);
-  --section-accent-muted: rgba(255, 152, 0, 0.14);
-  --section-accent-strong: rgba(255, 152, 0, 0.26);
-  --section-accent-icon-bg: rgba(255, 152, 0, 0.2);
-}
-
-.post-section[data-accent="purple"] {
-  --section-accent: var(--accent-purple);
-  --section-accent-muted: rgba(103, 58, 183, 0.14);
-  --section-accent-strong: rgba(103, 58, 183, 0.26);
-  --section-accent-icon-bg: rgba(103, 58, 183, 0.2);
+.post-section:hover,
+.post-section[data-open="true"] {
+  background: var(--card-bg-hover);
 }
 
 .post-section__heading {
@@ -672,20 +647,14 @@ main.container {
   padding: 1.1rem 1.5rem;
   min-height: 44px;
   border: none;
-  background: var(--section-accent-muted);
   color: var(--color-base);
   font-size: 1.1875rem;
   font-weight: 600;
   line-height: 1.3;
   text-align: left;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.post-section__toggle:hover,
-.post-section__toggle:focus-visible {
-  background: var(--section-accent-strong);
-  box-shadow: 0 8px 18px rgba(16, 33, 63, 0.12);
+  background: transparent;
+  transition: color var(--transition-fast);
 }
 
 .post-section__toggle:focus-visible {
@@ -695,7 +664,6 @@ main.container {
 }
 
 .post-section__toggle[aria-expanded="true"] {
-  background: var(--section-accent-strong);
   font-weight: 700;
   letter-spacing: 0.1px;
 }
@@ -769,6 +737,7 @@ main.container {
 .post-section__panel-inner {
   padding: 1.5rem 1.5rem 1.75rem;
   line-height: 1.6;
+  scroll-margin-top: calc(var(--sticky-header-height, 72px) + 12px);
 }
 
 .post-section__panel-inner > *:first-child {

--- a/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
+++ b/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Learn how to use a luggage scale to avoid overweight baggage fees with practical setup tips and repacking advice.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/avoid-overweight-baggage-fees-with-a-luggage-scale/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Avoid Overweight Baggage Fees with a Luggage Scale — Luggage Scale Blog">

--- a/blog/battery-free-luggage-scale-shake-to-charge/index.html
+++ b/blog/battery-free-luggage-scale-shake-to-charge/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Battery free luggage scale shake to charge explained: how kinetic charging works, step-by-step use, accuracy tips, and troubleshooting for dependable readings.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/battery-free-luggage-scale-shake-to-charge/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Battery-Free Luggage Scale (Shake-to-Charge): The Complete Guide — Luggage Scale Blog">

--- a/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
+++ b/blog/business-travel-weekly-packing-system-to-eliminate-overages/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Create a business travel packing system that pairs a luggage scale with smart prep so you never pay overweight bag fees again.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/business-travel-weekly-packing-system-to-eliminate-overages/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Business Travel: Weekly Packing System to Eliminate Overages — Luggage Scale Blog">

--- a/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
+++ b/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Use simple calibration tests and verification steps so you can rely on your luggage scale before leaving for the terminal.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/calibrate-verify-trusting-your-luggage-scale-s-readout/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Calibrate &amp; Verify: Trusting Your Luggage Scale’s Readout — Luggage Scale Blog">

--- a/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
+++ b/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Review carry-on baggage weight limits, airline differences, and simple luggage scale habits to stay compliant at the gate.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/carry-on-weight-limits-what-to-know-always-check-your-airline/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Carry‑On Weight Limits: What to Know (Always Check Your Airline) — Luggage Scale Blog">

--- a/blog/digital-luggage-scale/index.html
+++ b/blog/digital-luggage-scale/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Digital Luggage Scale description here.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/digital-luggage-scale/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Digital Luggage Scale – Blog Post — Luggage Scale Blog">

--- a/blog/durable-luggage-scale-frequent-flyers/index.html
+++ b/blog/durable-luggage-scale-frequent-flyers/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="A complete guide to choosing a durable luggage scale for frequent flyers: what durability really means, how it works, key benefits, comparisons, use cases, pro tips, FAQs, and a clear checklist.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/durable-luggage-scale-frequent-flyers/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Durable Luggage Scale – Built for Frequent Flyers — Luggage Scale Blog">

--- a/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
+++ b/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Follow a family travel luggage checklist that uses a scale to verify every bag quickly before you head to the airport.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/family-travel-checklist-weigh-every-bag-in-2-minutes/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Family Travel Checklist: Weigh Every Bag in 2 Minutes — Luggage Scale Blog">

--- a/blog/hello-world/index.html
+++ b/blog/hello-world/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Meet the uPatch luggage scale blog—a short hello explaining the articles and travel tips coming soon.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/hello-world/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Hello World — First Blog Post — Luggage Scale Blog">

--- a/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
+++ b/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Learn the correct way to power, zero, and read a battery-free luggage scale so you capture accurate weights anywhere.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/how-to-use-a-battery-free-shake-to-charge-luggage-scale/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="How to Use a Battery‑Free (Shake‑to‑Charge) Luggage Scale — Luggage Scale Blog">

--- a/blog/index.html
+++ b/blog/index.html
@@ -69,6 +69,8 @@
 <meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Blog — Luggage Scale Blog">

--- a/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
+++ b/blog/international-vs-domestic-trips-planning-for-weight-differences/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Compare international and domestic baggage weight limits and use a luggage scale to prepare for each itinerary with confidence.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/international-vs-domestic-trips-planning-for-weight-differences/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="International vs. Domestic Trips: Planning for Weight Differences — Luggage Scale Blog">

--- a/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
+++ b/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Try ten practical packing tips plus luggage scale checkpoints to avoid overweight fees at airline check-in counters.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/pack-like-a-pro-10-tips-to-keep-your-suitcase-under-50-lb/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Pack Like a Pro: 10 Tips to Keep Your Suitcase Under 50 lb — Luggage Scale Blog">

--- a/blog/page-2/index.html
+++ b/blog/page-2/index.html
@@ -69,6 +69,8 @@
 <meta name="description" content="Latest articles, guides, and tips from the uPatch luggage scale team.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/page-2/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Blog — Luggage Scale Blog">

--- a/blog/portable-luggage-scale/index.html
+++ b/blog/portable-luggage-scale/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Portable Luggage Scale description here.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/portable-luggage-scale/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Portable Luggage Scale – Blog Post — Luggage Scale Blog">

--- a/blog/static/post.js
+++ b/blog/static/post.js
@@ -16,24 +16,52 @@
   const getSectionElement = (trigger) =>
     trigger ? trigger.closest('[data-post-section]') : null;
 
-  const isElementTopInViewport = (element) => {
-    if (!element) return false;
-    const rect = element.getBoundingClientRect();
-    const viewportHeight =
-      window.innerHeight || document.documentElement.clientHeight || 0;
-    return rect.top >= 0 && rect.top <= viewportHeight;
+  const getPanelContent = (panel) =>
+    panel ? panel.querySelector('.post-section__panel-inner') || panel : null;
+
+  const getStickyHeaderOffset = () => {
+    const defaultHeight = 72;
+    const gap = 12;
+    const root = document.documentElement;
+    if (!root || typeof window.getComputedStyle !== 'function') {
+      return defaultHeight + gap;
+    }
+    const style = window.getComputedStyle(root);
+    if (!style) {
+      return defaultHeight + gap;
+    }
+    const parsed = parseFloat(style.getPropertyValue('--sticky-header-height'));
+    const headerHeight = Number.isNaN(parsed) ? defaultHeight : parsed;
+    return headerHeight + gap;
   };
 
-  const scrollSectionIntoView = (sectionEl, { behavior } = {}) => {
-    if (!sectionEl || typeof sectionEl.scrollIntoView !== 'function') {
+  const isContentTopFullyVisible = (element) => {
+    if (!element) return false;
+    const rect = element.getBoundingClientRect();
+    return rect.top >= getStickyHeaderOffset();
+  };
+
+  const scrollContentIntoView = (element, { behavior } = {}) => {
+    if (!element || typeof element.scrollIntoView !== 'function') {
       return;
     }
-    if (isElementTopInViewport(sectionEl)) {
+    if (isContentTopFullyVisible(element)) {
       return;
     }
     const scrollBehavior =
       behavior || (prefersReducedMotion() ? 'auto' : 'smooth');
-    sectionEl.scrollIntoView({ block: 'start', behavior: scrollBehavior });
+    element.scrollIntoView({ block: 'start', behavior: scrollBehavior });
+  };
+
+  const scheduleScrollToContent = (panel, options = {}) => {
+    const contentEl = getPanelContent(panel);
+    if (!contentEl) return;
+    const { behavior } = options;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        scrollContentIntoView(contentEl, { behavior });
+      });
+    });
   };
 
   const getPanel = (trigger) => {
@@ -43,7 +71,13 @@
 
   const setExpanded = (trigger, expand, options = {}) => {
     const panel = getPanel(trigger);
-    if (!panel) return;
+    const sectionElement = getSectionElement(trigger);
+    if (!panel) {
+      if (sectionElement) {
+        sectionElement.dataset.open = expand ? 'true' : 'false';
+      }
+      return;
+    }
 
     const { immediate = false, force = false } = options;
     const wasExpanded = trigger.getAttribute('aria-expanded') === 'true';
@@ -56,6 +90,9 @@
 
     panel.dataset.open = expand ? 'true' : 'false';
     panel.setAttribute('aria-hidden', expand ? 'false' : 'true');
+    if (sectionElement) {
+      sectionElement.dataset.open = expand ? 'true' : 'false';
+    }
 
     const skipAnimation = immediate || prefersReducedMotion();
 
@@ -116,13 +153,16 @@
     if (!trigger) return false;
 
     const sectionElement = getSectionElement(trigger);
+    const panel = getPanel(trigger);
     collapseAll(trigger, { immediate });
     setExpanded(trigger, true, { immediate, force: true });
 
     if (scroll) {
       const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
-      if (sectionElement) {
-        scrollSectionIntoView(sectionElement, { behavior });
+      if (panel) {
+        scheduleScrollToContent(panel, { behavior });
+      } else if (sectionElement) {
+        scrollContentIntoView(sectionElement, { behavior });
       } else {
         const heading = document.getElementById(targetId);
         if (heading && typeof heading.scrollIntoView === 'function') {
@@ -135,7 +175,6 @@
   };
 
   const handleToggle = (trigger) => {
-    const sectionElement = getSectionElement(trigger);
     const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
     const nextState = !isExpanded;
     if (nextState) {
@@ -143,7 +182,8 @@
     }
     setExpanded(trigger, nextState, { force: true });
     if (nextState) {
-      scrollSectionIntoView(sectionElement);
+      const panel = getPanel(trigger);
+      scheduleScrollToContent(panel);
     }
   };
 
@@ -191,6 +231,10 @@
     if (!panel) return;
     panel.dataset.open = 'true';
     panel.setAttribute('aria-hidden', 'false');
+    const sectionElement = getSectionElement(trigger);
+    if (sectionElement) {
+      sectionElement.dataset.open = 'true';
+    }
 
     trigger.addEventListener('click', () => handleToggle(trigger));
     trigger.addEventListener('keydown', handleKeyDown);

--- a/blog/static/style.css
+++ b/blog/static/style.css
@@ -615,48 +615,23 @@ main.container {
 }
 
 .post-section {
+  --card-bg: #EAF4FD;
+  --card-bg-hover: #D9ECFC;
   --section-accent: var(--brand);
-  --section-accent-muted: rgba(0, 86, 179, 0.12);
-  --section-accent-strong: rgba(0, 86, 179, 0.22);
+  --section-accent-muted: rgba(0, 86, 179, 0.18);
+  --section-accent-strong: rgba(0, 86, 179, 0.32);
   --section-accent-icon-bg: rgba(0, 86, 179, 0.18);
-  background: var(--bg-1);
+  background: var(--card-bg);
   border-radius: 0.75rem;
   box-shadow: var(--shadow-accordion);
   border: 1px solid rgba(16, 33, 63, 0.05);
   overflow: hidden;
-  scroll-margin-top: calc(var(--sticky-header-height, 72px) + 12px);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.post-section:nth-of-type(even) {
-  background: var(--bg-2);
-}
-
-.post-section[data-accent="teal"] {
-  --section-accent: var(--accent-teal);
-  --section-accent-muted: rgba(0, 150, 136, 0.12);
-  --section-accent-strong: rgba(0, 150, 136, 0.22);
-  --section-accent-icon-bg: rgba(0, 150, 136, 0.18);
-}
-
-.post-section[data-accent="green"] {
-  --section-accent: var(--accent-green);
-  --section-accent-muted: rgba(40, 167, 69, 0.12);
-  --section-accent-strong: rgba(40, 167, 69, 0.22);
-  --section-accent-icon-bg: rgba(40, 167, 69, 0.18);
-}
-
-.post-section[data-accent="orange"] {
-  --section-accent: var(--accent-orange);
-  --section-accent-muted: rgba(255, 152, 0, 0.14);
-  --section-accent-strong: rgba(255, 152, 0, 0.26);
-  --section-accent-icon-bg: rgba(255, 152, 0, 0.2);
-}
-
-.post-section[data-accent="purple"] {
-  --section-accent: var(--accent-purple);
-  --section-accent-muted: rgba(103, 58, 183, 0.14);
-  --section-accent-strong: rgba(103, 58, 183, 0.26);
-  --section-accent-icon-bg: rgba(103, 58, 183, 0.2);
+.post-section:hover,
+.post-section[data-open="true"] {
+  background: var(--card-bg-hover);
 }
 
 .post-section__heading {
@@ -672,20 +647,14 @@ main.container {
   padding: 1.1rem 1.5rem;
   min-height: 44px;
   border: none;
-  background: var(--section-accent-muted);
   color: var(--color-base);
   font-size: 1.1875rem;
   font-weight: 600;
   line-height: 1.3;
   text-align: left;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.post-section__toggle:hover,
-.post-section__toggle:focus-visible {
-  background: var(--section-accent-strong);
-  box-shadow: 0 8px 18px rgba(16, 33, 63, 0.12);
+  background: transparent;
+  transition: color var(--transition-fast);
 }
 
 .post-section__toggle:focus-visible {
@@ -695,7 +664,6 @@ main.container {
 }
 
 .post-section__toggle[aria-expanded="true"] {
-  background: var(--section-accent-strong);
   font-weight: 700;
   letter-spacing: 0.1px;
 }
@@ -769,6 +737,7 @@ main.container {
 .post-section__panel-inner {
   padding: 1.5rem 1.5rem 1.75rem;
   line-height: 1.6;
+  scroll-margin-top: calc(var(--sticky-header-height, 72px) + 12px);
 }
 
 .post-section__panel-inner > *:first-child {

--- a/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
+++ b/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Get techniques for weighing strollers, golf bags, instruments, and other awkward gear accurately with a handheld luggage scale.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/weigh-odd-shaped-items-strollers-golf-bags-instruments/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Weigh Odd‑Shaped Items (Strollers, Golf Bags, Instruments) — Luggage Scale Blog">

--- a/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
+++ b/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/index.html
@@ -65,6 +65,8 @@
 <meta name="description" content="Use a luggage scale and smart packing strategy to manage winter gear weight so your cold-weather suitcase stays under the limit.">
 
 <link rel="canonical" href="https://luggage-scale.com/blog/winter-gear-strategy-coats-boots-and-heavy-fabrics/">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="shortcut icon" href="/favicon.ico">
 
 <meta property="og:site_name" content="Luggage Scale Blog">
 <meta property="og:title" content="Winter Gear Strategy: Coats, Boots, and Heavy Fabrics — Luggage Scale Blog">


### PR DESCRIPTION
## Summary
- apply shared background variables to every accordion section card so hover and open states use the same neutral color
- update the accordion script to scroll the revealed panel content into view with the sticky-header offset and to flag the open card for styling
- add favicon references that point to `/favicon.ico` in the shared head include and generated blog pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d36fa5ebf8833284aba27a8f633a8b